### PR TITLE
Update member dashboard with balance

### DIFF
--- a/frontend/src/MemberDashboard.test.js
+++ b/frontend/src/MemberDashboard.test.js
@@ -43,6 +43,8 @@ test('renders dashboard sections', async () => {
   expect(chargesHeading).toBeInTheDocument();
   const paymentsHeading = screen.getByRole('heading', { name: /recent payments/i });
   expect(paymentsHeading).toBeInTheDocument();
+  const balance = screen.getByText(/total balance due/i);
+  expect(balance).toHaveTextContent('$200');
 });
 
 test('shows review payment button for charges', async () => {

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -48,9 +48,19 @@ export default function MemberDashboard({
     return <div>Loading…</div>;
   }
 
+  const totalBalance = chargeData
+    .filter((c) => c.status !== 'Paid')
+    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
+
   return (
     <div className="member-dashboard">
       <h1>Dashboard</h1>
+
+      <div className="balance-info">
+        Your total balance due is{' '}
+        <strong>{`$${totalBalance}`}</strong>. Please send payment to the chapter
+        Zelle and submit a payment review when complete.
+      </div>
 
       <section>
         <h2>Outstanding Charges</h2>

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -10,3 +10,10 @@
   flex-direction: column;
   gap: 12px;
 }
+
+.balance-info {
+  background-color: #f5f5f5;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 1.1rem;
+}


### PR DESCRIPTION
## Summary
- show a balance info blurb at the top of the member dashboard
- style the balance info box
- update dashboard tests for new message

## Testing
- `CI=true npm --prefix frontend test --silent`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_686e94a7a99483288c9cec48d511b3bd