### PR TITLE
Add amount paid input to review form

### DIFF
--- a/frontend/src/PaymentReviewForm.test.js
+++ b/frontend/src/PaymentReviewForm.test.js
@@ -23,6 +23,10 @@ test('successful submit shows confirmation message', async () => {
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
   );
+  await userEvent.type(
+    screen.getByLabelText(/amount paid/i),
+    '100'
+  );
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(await screen.findByText(/submitted/i)).toBeInTheDocument();
 });
@@ -36,6 +40,10 @@ test('failed submit shows error message', async () => {
     <AuthProvider>
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
+  );
+  await userEvent.type(
+    screen.getByLabelText(/amount paid/i),
+    '50'
   );
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(await screen.findByText('Bad request')).toBeInTheDocument();

--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -6,6 +6,7 @@ const sampleCharge = { id: 1, amount: '$200' };
 
 export default function PaymentReviewForm({ charge = sampleCharge, onBack }) {
   const [memo, setMemo] = useState('');
+  const [amountPaid, setAmountPaid] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const api = useApi();
@@ -15,9 +16,14 @@ export default function PaymentReviewForm({ charge = sampleCharge, onBack }) {
     setError('');
     setMessage('');
     try {
-      await api.submitReview({ chargeId: charge.id, amount: charge.amount, memo });
+      await api.submitReview({
+        chargeId: charge.id,
+        amount: amountPaid,
+        memo
+      });
       setMessage('Review request submitted');
       setMemo('');
+      setAmountPaid('');
     } catch (err) {
       setError(err.message);
     }
@@ -33,6 +39,14 @@ export default function PaymentReviewForm({ charge = sampleCharge, onBack }) {
         <div className="static-field">
           <strong>Amount:</strong> {charge.amount}
         </div>
+        <label>
+          Amount Paid
+          <input
+            type="number"
+            value={amountPaid}
+            onChange={(e) => setAmountPaid(e.target.value)}
+          />
+        </label>
         <label>
           Memo
           <input


### PR DESCRIPTION
## Summary
- allow members to specify the amount they paid when requesting a payment review
- reset entered amount after successful submit
- update tests for new form field

## Testing
- `CI=true npm test --silent`
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_686e950486288328af45c69ecd51e394