### PR TITLE
Update backend to load CSV mock data for supabase compatibility

### DIFF
--- a/SupabaseSetup.md
+++ b/SupabaseSetup.md
@@ -36,7 +36,9 @@ create table if not exists charges (
 
 ```
 
-You can import existing `mockData.json` through the Supabase table editor or by converting it to CSV and using the **Import Data** option.
+Sample data is available in the `mock-data` directory. You can import the
+`profiles.csv` and `charges.csv` files directly through the Supabase table
+editor using the **Import Data** option.
 
 ## 3. Backend configuration
 1. Install dependencies:

--- a/backend/index.js
+++ b/backend/index.js
@@ -20,7 +20,7 @@ app.use('/api/members', membersRoute);
 app.use('/api/charges', chargesRoute);
 
 // In-memory data for Phase 2
-const data = require('../mockData.json');
+const data = require('./mockData');
 let members = data.members;
 let charges = data.charges;
 let nextMemberId = Math.max(...members.map((m) => m.id)) + 1;

--- a/backend/mockData.js
+++ b/backend/mockData.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const { parse } = require('csv-parse/sync');
+
+function loadCsv(file) {
+  const csv = fs.readFileSync(path.join(__dirname, '..', 'mock-data', file), 'utf8');
+  return parse(csv, { columns: true, skip_empty_lines: true });
+}
+
+const profileRows = loadCsv('profiles.csv');
+const idMap = new Map();
+let nextId = 1;
+const members = profileRows.map((row) => {
+  const numId = nextId++;
+  idMap.set(row.id, numId);
+  return {
+    id: numId,
+    email: row.email,
+    password: row.email === 'admin@example.com' ? 'admin' : 'password',
+    name: row.name,
+    isAdmin: row.is_admin === 'true' || row.is_admin === true,
+    status: row.status,
+    initiationDate: row.initiation_date,
+    amountOwed: Number(row.amount_owed),
+    tags: row.tags ? row.tags.replace(/[{}]/g, '').split(',').map(t => t.trim()).filter(Boolean) : []
+  };
+});
+
+const charges = loadCsv('charges.csv').map((row) => ({
+  id: Number(row.id),
+  memberId: idMap.get(row.member_id) || Number(row.member_id) || 0,
+  status: row.status,
+  amount: Number(row.amount),
+  dueDate: row.due_date,
+  description: row.description,
+  tags: row.tags ? row.tags.replace(/[{}]/g, '').split(',').map(t => t.trim()).filter(Boolean) : []
+}));
+
+module.exports = { members, charges };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.5",
+        "csv-parse": "^5.6.0",
         "express": "^5.1.0"
       }
     },
@@ -243,6 +244,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0",
-    "@supabase/supabase-js": "^2.50.5"
+    "@supabase/supabase-js": "^2.50.5",
+    "csv-parse": "^5.6.0",
+    "express": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- use new CSV mock data files instead of removed mockData.json
- add csv-parse dependency and parsing module
- update Supabase setup guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68706d0b4824832899987209efd308f2