### PR TITLE
Remove API env variable

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,5 +37,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:3001"
+  "proxy": "https://conclave-app.onrender.com/api"
 }

--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -1,8 +1,7 @@
 import { useAuth } from './AuthContext';
 
-const API_BASE = process.env.REACT_APP_API_URL
-  ? `${process.env.REACT_APP_API_URL}/api`
-  : '/api';
+// Use the deployed API directly without relying on an environment variable
+const API_BASE = 'https://conclave-app.onrender.com/api';
 
 export function useApi() {
   const { token } = useAuth();


### PR DESCRIPTION
## Summary
- set the CRA proxy to the deployed server
- hardcode API base URL to the hosted service

## Testing
- `npm test` in `backend`
- `npm test -- --watchAll=false` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6870b8adafb88328b531cf1894019da2