### PR TITLE
Verify tokens with Supabase server client

### DIFF
--- a/backend/adminClient.js
+++ b/backend/adminClient.js
@@ -1,0 +1,21 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://tsbyrpuskzsrmjfwckzh.supabase.co';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+let supabaseAdmin;
+if (SERVICE_ROLE_KEY) {
+  supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+} else {
+  supabaseAdmin = {
+    auth: {
+      async getUser() {
+        return { data: { user: null }, error: new Error('Service role key missing') };
+      }
+    }
+  };
+}
+
+module.exports = supabaseAdmin;


### PR DESCRIPTION
## Summary
- create an admin Supabase client for server-side token validation
- use that client in the auth middleware

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68714b834f448328aa8e6ac54a7d17c0