### PR TITLE
Use Supabase admin key for token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ This project will be maintained in its own repository (`conclave-app`) and will 
    cd backend
    npm start
    ```
-The backend requires `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and
-`SUPABASE_JWT_SECRET` environment variables. See `SupabaseSetup.md` for
-details on configuring the database and obtaining these values.
+The backend requires the following environment variables:
+`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_JWT_SECRET`, and
+`SUPABASE_SERVICE_ROLE_KEY`. See `SupabaseSetup.md` for details on
+configuring the database and obtaining these values.
 
 ### Authentication in Development
 

--- a/SupabaseSetup.md
+++ b/SupabaseSetup.md
@@ -50,6 +50,7 @@ editor using the **Import Data** option.
    - `SUPABASE_URL`
    - `SUPABASE_ANON_KEY`
    - `SUPABASE_JWT_SECRET` (found under Project Settings → API)
+   - `SUPABASE_SERVICE_ROLE_KEY` (also under Project Settings → API)
 3. Deploy the backend to Render as a web service pointing to `backend/index.js`.
 
 The `/signup` endpoint in `index.js` demonstrates how to create a user with Supabase auth and store additional info in the `profiles` table.

--- a/backend/index.js
+++ b/backend/index.js
@@ -126,8 +126,12 @@ async function auth(req, res, next) {
     }
   }
 
-  const { data: { user }, error } = await supabaseAdmin.auth.getUser(token);
+  const {
+    data: { user },
+    error
+  } = await supabaseAdmin.auth.getUser(token);
   if (error || !user) {
+    console.error('Supabase auth failed:', error);
     return res.status(401).send('Invalid token');
   }
   req.memberId = user.id;


### PR DESCRIPTION
## Summary
- log errors from Supabase token validation
- document that SUPABASE_SERVICE_ROLE_KEY is required
- mention service role key in Supabase setup guide

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6871611149ec8328bea796f72739114a