### PR TITLE
Improve front-end test coverage

### DIFF
--- a/frontend/src/NotificationContainer.test.js
+++ b/frontend/src/NotificationContainer.test.js
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NotificationContainer from './components/NotificationContainer';
+import { useNotifications } from './NotificationContext';
+
+jest.mock('./NotificationContext');
+
+test('renders notifications from context', () => {
+  const removeNotification = jest.fn();
+  useNotifications.mockReturnValue({
+    notifications: [{ id: 1, message: 'Hello' }],
+    removeNotification,
+  });
+  render(<NotificationContainer />);
+  expect(screen.getByText('Hello')).toBeInTheDocument();
+});
+
+test('close button removes notification', async () => {
+  const removeNotification = jest.fn();
+  useNotifications.mockReturnValue({
+    notifications: [{ id: 2, message: 'Bye' }],
+    removeNotification,
+  });
+  render(<NotificationContainer />);
+  const button = screen.getByRole('button', { name: /close notification/i });
+  await userEvent.click(button);
+  expect(removeNotification).toHaveBeenCalledWith(2);
+});

--- a/frontend/src/SearchBar.test.js
+++ b/frontend/src/SearchBar.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SearchBar from './components/SearchBar';
+import { useState } from 'react';
+
+test('renders with value and placeholder', () => {
+  const handleChange = jest.fn();
+  render(<SearchBar value="abc" onChange={handleChange} placeholder="Find" />);
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('abc');
+  expect(input).toHaveAttribute('placeholder', 'Find');
+});
+
+test('calls onChange when typing', async () => {
+  function Wrapper() {
+    const [val, setVal] = useState('');
+    return <SearchBar value={val} onChange={setVal} />;
+  }
+  render(<Wrapper />);
+  const input = screen.getByRole('textbox');
+  await userEvent.type(input, 'hi');
+  expect(input).toHaveValue('hi');
+});


### PR DESCRIPTION
## Summary
- add tests for SearchBar component
- add tests for NotificationContainer

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6871a7d2303c8328a340e2525ce6c0b9