### PR TITLE
Implement payment review workflow updates

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -341,7 +341,16 @@ app.delete('/api/admin/charges/:id', auth, adminOnly, (req, res) => {
 
 // List all submitted payment reviews
 app.get('/api/admin/reviews', auth, adminOnly, (req, res) => {
-  res.json(reviews);
+  const enriched = reviews.map((r) => {
+    const charge = charges.find((c) => c.id === r.chargeId) || {};
+    return {
+      ...r,
+      chargeDescription: charge.description,
+      originalAmount: charge.amount,
+      amountPaid: r.amount
+    };
+  });
+  res.json(enriched);
 });
 
 // Approve a review and mark the associated charge as paid

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -103,11 +103,11 @@ test('dashboard review button opens form with charge data', async () => {
     </AuthProvider>
   );
   await userEvent.click(screen.getByRole('button', { name: /dashboard/i }));
-  const reviewButtons = await screen.findAllByRole('button', { name: /request review/i });
+  const reviewButtons = await screen.findAllByRole('button', { name: /mark as paid/i });
   await userEvent.click(reviewButtons[0]);
   const heading = await screen.findByRole('heading', { name: /payment review/i });
   expect(heading).toBeInTheDocument();
-  expect(screen.getByText(/charge id:/i)).toBeInTheDocument();
+  expect(screen.getByText(/description:/i)).toBeInTheDocument();
 });
 
 test('dashboard tile review button opens form', async () => {
@@ -134,7 +134,7 @@ test('dashboard details button opens details page then review form', async () =>
   await userEvent.click(detailButtons[0]);
   const detailHeading = await screen.findByRole('heading', { name: /charge details/i });
   expect(detailHeading).toBeInTheDocument();
-  const requestBtn = await screen.findByRole('button', { name: /request review/i });
+  const requestBtn = await screen.findByRole('button', { name: /mark as paid/i });
   await userEvent.click(requestBtn);
   expect(await screen.findByRole('heading', { name: /payment review/i })).toBeInTheDocument();
 });

--- a/frontend/src/MemberDashboard.test.js
+++ b/frontend/src/MemberDashboard.test.js
@@ -60,7 +60,7 @@ test('shows review payment button for charges', async () => {
       <MemberDashboard />
     </AuthProvider>
   );
-  const reviewButtons = await screen.findAllByRole('button', { name: /request review/i });
+  const reviewButtons = await screen.findAllByRole('button', { name: /mark as paid/i });
   expect(reviewButtons.length).toBeGreaterThan(0);
 });
 

--- a/frontend/src/PaymentReviewForm.test.js
+++ b/frontend/src/PaymentReviewForm.test.js
@@ -23,10 +23,8 @@ test('successful submit shows confirmation message', async () => {
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
   );
-  await userEvent.type(
-    screen.getByLabelText(/amount paid/i),
-    '100'
-  );
+  const input = screen.getByLabelText(/amount paid/i);
+  expect(input).toHaveValue(100);
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(await screen.findByText(/submitted/i)).toBeInTheDocument();
 });
@@ -41,10 +39,9 @@ test('failed submit shows error message', async () => {
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
   );
-  await userEvent.type(
-    screen.getByLabelText(/amount paid/i),
-    '50'
-  );
+  const input = screen.getByLabelText(/amount paid/i);
+  await userEvent.clear(input);
+  await userEvent.type(input, '50');
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(await screen.findByText('Bad request')).toBeInTheDocument();
 });

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -50,18 +50,18 @@ export default function AdminDashboard({ onShowMembers, onShowCharges }) {
         <table className="admin-table">
           <thead>
             <tr>
-              <th>ID</th>
-              <th>Charge</th>
-              <th>Amount</th>
+              <th>Charge Description</th>
+              <th>Original Amount</th>
+              <th>Amount Paid</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             {reviews.map((r) => (
               <tr key={r.id}>
-                <td>{r.id}</td>
-                <td>{r.chargeId}</td>
-                <td>{r.amount}</td>
+                <td>{r.chargeDescription}</td>
+                <td>{r.originalAmount}</td>
+                <td>{r.amountPaid ?? r.amount}</td>
                 <td className="flex space-x-2">
                   <button onClick={() => handleApprove(r.id)}>Approve</button>
                   <button onClick={() => handleReject(r.id)}>Reject</button>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -14,6 +14,7 @@ function App() {
   const [currentPage, setCurrentPage] = useState('login');
   const [reviewCharge, setReviewCharge] = useState(null);
   const [detailsCharge, setDetailsCharge] = useState(null);
+  const [pendingReviewIds, setPendingReviewIds] = useState([]);
   const { setToken, setUser, user } = useAuth();
 
   const showDashboard = () => {
@@ -36,6 +37,9 @@ function App() {
     }
     setCurrentPage('review');
   };
+
+  const markPendingReview = (id) =>
+    setPendingReviewIds((ids) => (ids.includes(id) ? ids : [...ids, id]));
   const showChargeDetails = (charge) => {
     if (charge) {
       setDetailsCharge(charge);
@@ -50,12 +54,17 @@ function App() {
         <MemberDashboard
           onRequestReview={showReview}
           onViewDetails={showChargeDetails}
+          pendingReviewIds={pendingReviewIds}
         />
       );
       break;
     case 'review':
       pageContent = (
-        <PaymentReviewForm charge={reviewCharge || undefined} onBack={showDashboard} />
+        <PaymentReviewForm
+          charge={reviewCharge || undefined}
+          onBack={showDashboard}
+          onSubmitted={markPendingReview}
+        />
       );
       break;
     case 'chargeDetails':

--- a/frontend/src/components/ChargeDetails.js
+++ b/frontend/src/components/ChargeDetails.js
@@ -44,7 +44,7 @@ export default function ChargeDetails({ charge, onRequestReview, onBack }) {
             className="request-review-button"
             onClick={() => onRequestReview(displayCharge)}
           >
-            Request Review
+            Mark as Paid
           </button>
         )}
         {onBack && (

--- a/frontend/src/components/ChargeItem.js
+++ b/frontend/src/components/ChargeItem.js
@@ -1,23 +1,28 @@
 export default function ChargeItem({
   id,
   status,
+  description,
   amount,
   dueDate,
   onRequestReview = () => {},
   onViewDetails = () => {},
+  pending = false,
 }) {
   return (
     <tr className="charge-item">
       <td>{status}</td>
+      <td>{description || '-'}</td>
       <td>{amount}</td>
       <td>{new Date(dueDate).toLocaleDateString()}</td>
       <td className="flex space-x-2">  {/* Tailwind flex + gap */}
         <button
           type="button"
-          onClick={() => onRequestReview({ id, amount })}
-          className="px-3 py-1 bg-blue-500 text-white rounded"
+          onClick={() => onRequestReview({ id, amount, description })}
+          className={`px-3 py-1 rounded ${pending ? 'bg-gray-300 text-gray-600 cursor-not-allowed' : 'bg-blue-500 text-white'}`}
+          disabled={pending}
+          title={pending ? 'Your payment is being reviewed by the Quaestor.' : undefined}
         >
-          Request Review
+          {pending ? 'Pending Review' : 'Mark as Paid'}
         </button>
         <button
           type="button"

--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -6,6 +6,7 @@ export default function ChargeList({
   charges,
   onRequestReview = () => {},
   onViewDetails = () => {},
+  pendingReviewIds = [],
 }) {
   if (!charges || charges.length === 0) {
     return <div className="charge-list-empty">No charges found.</div>;
@@ -16,6 +17,7 @@ export default function ChargeList({
       <thead>
         <tr>
           <th>Status</th>
+          <th>Description</th>
           <th>Amount</th>
           <th>Due Date</th>
           <th>Actions</th>
@@ -28,6 +30,7 @@ export default function ChargeList({
             {...charge}
             onRequestReview={onRequestReview}
             onViewDetails={onViewDetails}
+            pending={pendingReviewIds.includes(charge.id)}
           />
         ))}
       </tbody>

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -8,6 +8,7 @@ import { useAuth } from '../AuthContext';
 export default function MemberDashboard({
   onRequestReview = () => {},
   onViewDetails = () => {},
+  pendingReviewIds = [],
 }) {
   const [chargeData, setChargeData] = useState([]);
   const [paymentData, setPaymentData] = useState([]);
@@ -68,7 +69,7 @@ export default function MemberDashboard({
           data-testid="dashboard-review-button"
           onClick={() => onRequestReview()}
         >
-          Payment Review
+          Mark as Paid
         </button>
       </div>
 
@@ -78,6 +79,7 @@ export default function MemberDashboard({
           charges={chargeData}
           onRequestReview={onRequestReview}
           onViewDetails={onViewDetails}
+          pendingReviewIds={pendingReviewIds}
         />
       </section>
 

--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -1,17 +1,25 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import '../styles/PaymentReviewForm.css';
 import useApi from '../apiClient';
 import { useNotifications } from '../NotificationContext';
 
-const sampleCharge = { id: 1, amount: '$200' };
+const sampleCharge = { id: 1, amount: '$200', description: 'Charge' };
 
-export default function PaymentReviewForm({ charge = sampleCharge, onBack }) {
+export default function PaymentReviewForm({
+  charge = sampleCharge,
+  onBack,
+  onSubmitted
+}) {
   const [memo, setMemo] = useState('');
   const [amountPaid, setAmountPaid] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const api = useApi();
   const { addNotification } = useNotifications();
+
+  useEffect(() => {
+    setAmountPaid(charge && charge.id ? charge.amount : '');
+  }, [charge]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -26,7 +34,8 @@ export default function PaymentReviewForm({ charge = sampleCharge, onBack }) {
       setMessage('Review request submitted');
       setMemo('');
       setAmountPaid('');
-      addNotification('Review submitted successfully');
+      addNotification('Your payment review has been submitted successfully.');
+      if (onSubmitted && charge && charge.id) onSubmitted(charge.id);
       if (onBack) onBack();
     } catch (err) {
       setError(err.message);
@@ -38,7 +47,7 @@ export default function PaymentReviewForm({ charge = sampleCharge, onBack }) {
       <h1>Payment Review</h1>
       <form onSubmit={handleSubmit} className="review-form">
         <div className="static-field">
-          <strong>Charge ID:</strong> {charge.id}
+          <strong>Description:</strong> {charge.description || '-'}
         </div>
         <div className="static-field">
           <strong>Amount:</strong> {charge.amount}

--- a/frontend/src/styles/Notifications.css
+++ b/frontend/src/styles/Notifications.css
@@ -9,9 +9,9 @@
 }
 
 .notification {
-  background-color: #333;
+  background-color: #4caf50;
   color: #fff;
-  padding: 10px 16px;
+  padding: 12px 18px;
   border-radius: 4px;
   min-width: 200px;
   position: relative;
@@ -19,12 +19,12 @@
 
 .notification-close {
   position: absolute;
-  top: 2px;
-  right: 4px;
+  top: 4px;
+  right: 8px;
   background: transparent;
   border: none;
   color: #fff;
   cursor: pointer;
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
- autofill payment amount when marking charges paid
- disable "Mark as Paid" buttons while pending review
- show charge descriptions and updated review table columns
- improve success notification style
- adjust tests for new workflow

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6871a666b0a4832888e11e169886d134