### PR TITLE
Add lump sum payment flow

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -103,8 +103,8 @@ test('dashboard review button opens form with charge data', async () => {
     </AuthProvider>
   );
   await userEvent.click(screen.getByRole('button', { name: /dashboard/i }));
-  const reviewButtons = await screen.findAllByRole('button', { name: /mark as paid/i });
-  await userEvent.click(reviewButtons[0]);
+  const reviewButton = await screen.findByRole('button', { name: /mark as paid/i });
+  await userEvent.click(reviewButton);
   const heading = await screen.findByRole('heading', { name: /payment review/i });
   expect(heading).toBeInTheDocument();
   expect(screen.getByText(/description:/i)).toBeInTheDocument();
@@ -134,9 +134,7 @@ test('dashboard details button opens details page then review form', async () =>
   await userEvent.click(detailButtons[0]);
   const detailHeading = await screen.findByRole('heading', { name: /charge details/i });
   expect(detailHeading).toBeInTheDocument();
-  const requestBtn = await screen.findByRole('button', { name: /mark as paid/i });
-  await userEvent.click(requestBtn);
-  expect(await screen.findByRole('heading', { name: /payment review/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /mark as paid/i })).not.toBeInTheDocument();
 });
 
 test('charge details back button returns to dashboard', async () => {

--- a/frontend/src/MemberDashboard.test.js
+++ b/frontend/src/MemberDashboard.test.js
@@ -46,13 +46,9 @@ test('renders dashboard sections', async () => {
     name: /recent payments/i
   });
   expect(paymentsHeading).toBeInTheDocument();
-  const amount = screen.getByText('$200');
-  expect(amount).toBeInTheDocument();
-  const instructions = screen.getByText(
-    /please send payment to the chapter zelle/i
-  );
-  expect(instructions).toBeInTheDocument();
-  expect(screen.getByText(/overdue balance: \$200/i)).toBeInTheDocument();
+  const total = screen.getByTestId('total-balance');
+  expect(total).toHaveTextContent('$200');
+  expect(screen.getByTestId('overdue-balance')).toHaveTextContent('$200');
 });
 
 
@@ -73,7 +69,7 @@ test('dashboard payment review button triggers callback', async () => {
       <MemberDashboard onRequestReview={onRequestReview} />
     </AuthProvider>
   );
-  await screen.findByText('$200');
+  await screen.findByTestId('total-balance');
   const button = screen.getByTestId('dashboard-review-button');
   await userEvent.click(button);
   expect(onRequestReview).toHaveBeenCalled();

--- a/frontend/src/MemberDashboard.test.js
+++ b/frontend/src/MemberDashboard.test.js
@@ -52,17 +52,9 @@ test('renders dashboard sections', async () => {
     /please send payment to the chapter zelle/i
   );
   expect(instructions).toBeInTheDocument();
+  expect(screen.getByText(/overdue balance: \$200/i)).toBeInTheDocument();
 });
 
-test('shows review payment button for charges', async () => {
-  render(
-    <AuthProvider>
-      <MemberDashboard />
-    </AuthProvider>
-  );
-  const reviewButtons = await screen.findAllByRole('button', { name: /mark as paid/i });
-  expect(reviewButtons.length).toBeGreaterThan(0);
-});
 
 test('shows details button for charges', async () => {
   render(

--- a/frontend/src/PaymentReviewForm.test.js
+++ b/frontend/src/PaymentReviewForm.test.js
@@ -45,3 +45,14 @@ test('failed submit shows error message', async () => {
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(await screen.findByText('Bad request')).toBeInTheDocument();
 });
+
+test('prefills amount for lump sum payment', () => {
+  setupLocalStorage();
+  render(
+    <AuthProvider>
+      <PaymentReviewForm charge={{ amount: 250 }} />
+    </AuthProvider>
+  );
+  const input = screen.getByLabelText(/amount paid/i);
+  expect(input).toHaveValue(250);
+});

--- a/frontend/src/balanceUtils.js
+++ b/frontend/src/balanceUtils.js
@@ -1,0 +1,22 @@
+export function getBalanceBreakdown(charges, today = new Date()) {
+  const unpaid = charges.filter((c) => c.status !== 'Paid');
+  const totalBalance = unpaid.reduce((sum, c) => sum + Number(c.amount || 0), 0);
+  const overdueBalance = unpaid
+    .filter((c) => new Date(c.dueDate) < today)
+    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
+  const dueSoonBalance = unpaid
+    .filter((c) => {
+      const due = new Date(c.dueDate);
+      const diff = (due - today) / (1000 * 60 * 60 * 24);
+      return diff >= 0 && diff <= 7;
+    })
+    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
+  const upcomingBalance = unpaid
+    .filter((c) => {
+      const due = new Date(c.dueDate);
+      const diff = (due - today) / (1000 * 60 * 60 * 24);
+      return diff > 7;
+    })
+    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
+  return { totalBalance, overdueBalance, dueSoonBalance, upcomingBalance };
+}

--- a/frontend/src/balanceUtils.test.js
+++ b/frontend/src/balanceUtils.test.js
@@ -1,0 +1,16 @@
+import { getBalanceBreakdown } from './balanceUtils';
+
+test('computes balance categories relative to reference date', () => {
+  const charges = [
+    { id: 1, status: 'Outstanding', amount: 50, dueDate: '2024-01-01' },
+    { id: 2, status: 'Outstanding', amount: 75, dueDate: '2024-01-05' },
+    { id: 3, status: 'Outstanding', amount: 100, dueDate: '2024-01-20' },
+    { id: 4, status: 'Paid', amount: 200, dueDate: '2024-01-01' },
+  ];
+  const today = new Date('2024-01-03');
+  const result = getBalanceBreakdown(charges, today);
+  expect(result.totalBalance).toBe(225);
+  expect(result.overdueBalance).toBe(50);
+  expect(result.dueSoonBalance).toBe(75);
+  expect(result.upcomingBalance).toBe(100);
+});

--- a/frontend/src/components/ChargeDetails.js
+++ b/frontend/src/components/ChargeDetails.js
@@ -38,15 +38,6 @@ export default function ChargeDetails({ charge, onRequestReview, onBack }) {
       </table>
 
       <div className="charge-actions">
-        {onRequestReview && (
-          <button
-            type="button"
-            className="request-review-button"
-            onClick={() => onRequestReview(displayCharge)}
-          >
-            Mark as Paid
-          </button>
-        )}
         {onBack && (
           <button type="button" onClick={onBack} className="back-button">
             Back

--- a/frontend/src/components/ChargeItem.js
+++ b/frontend/src/components/ChargeItem.js
@@ -17,15 +17,6 @@ export default function ChargeItem({
       <td className="flex space-x-2">  {/* Tailwind flex + gap */}
         <button
           type="button"
-          onClick={() => onRequestReview({ id, amount, description })}
-          className={`px-3 py-1 rounded ${pending ? 'bg-gray-300 text-gray-600 cursor-not-allowed' : 'bg-blue-500 text-white'}`}
-          disabled={pending}
-          title={pending ? 'Your payment is being reviewed by the Quaestor.' : undefined}
-        >
-          {pending ? 'Pending Review' : 'Mark as Paid'}
-        </button>
-        <button
-          type="button"
           onClick={() => onViewDetails({ id, status, amount, dueDate })}
           className="px-3 py-1 bg-gray-200 text-gray-800 rounded"
         >

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -4,6 +4,7 @@ import PaymentList from './PaymentList';
 import '../styles/MemberDashboard.css';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
+import { getBalanceBreakdown } from '../balanceUtils';
 
 export default function MemberDashboard({
   onRequestReview = () => {},
@@ -49,44 +50,48 @@ export default function MemberDashboard({
     return <div>Loading…</div>;
   }
 
-  const unpaidCharges = chargeData.filter((c) => c.status !== 'Paid');
-  const totalBalance = unpaidCharges.reduce(
-    (sum, c) => sum + Number(c.amount || 0),
-    0
-  );
-  const today = new Date();
-  const overdueBalance = unpaidCharges
-    .filter((c) => new Date(c.dueDate) < today)
-    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
-  const dueSoonBalance = unpaidCharges
-    .filter((c) => {
-      const due = new Date(c.dueDate);
-      const diff = (due - today) / (1000 * 60 * 60 * 24);
-      return diff >= 0 && diff <= 7;
-    })
-    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
-  const upcomingBalance = unpaidCharges
-    .filter((c) => {
-      const due = new Date(c.dueDate);
-      const diff = (due - today) / (1000 * 60 * 60 * 24);
-      return diff > 7;
-    })
-    .reduce((sum, c) => sum + Number(c.amount || 0), 0);
+  const breakdown = getBalanceBreakdown(chargeData);
+  const {
+    totalBalance,
+    overdueBalance,
+    dueSoonBalance,
+    upcomingBalance
+  } = breakdown;
 
   return (
     <div className="member-dashboard">
       <h1>Dashboard</h1>
 
       <div className="balance-info" data-testid="balance-info">
-        <div className="balance-amount">{`$${totalBalance}`}</div>
-        <div className="balance-text">
-          Total balance due. Please send payment to the chapter Zelle and submit
-          a payment review when complete.
-        </div>
-        <div className="balance-breakdown">
-          <div>{`Overdue Balance: $${overdueBalance}`}</div>
-          <div>{`Due Soon (≤7 days): $${dueSoonBalance}`}</div>
-          <div>{`Upcoming (>7 days): $${upcomingBalance}`}</div>
+        <div className="balance-summary">
+          <div
+            className="balance-card total"
+            data-testid="total-balance"
+          >
+            <div className="amount">{`$${totalBalance}`}</div>
+            <div className="label">Total Balance Due</div>
+          </div>
+          <div
+            className="balance-card overdue"
+            data-testid="overdue-balance"
+          >
+            <div className="amount">{`$${overdueBalance}`}</div>
+            <div className="label">Overdue</div>
+          </div>
+          <div
+            className="balance-card due-soon"
+            data-testid="due-soon-balance"
+          >
+            <div className="amount">{`$${dueSoonBalance}`}</div>
+            <div className="label">Due Soon (≤7d)</div>
+          </div>
+          <div
+            className="balance-card upcoming"
+            data-testid="upcoming-balance"
+          >
+            <div className="amount">{`$${upcomingBalance}`}</div>
+            <div className="label">Upcoming</div>
+          </div>
         </div>
         <button
           type="button"

--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -18,7 +18,11 @@ export default function PaymentReviewForm({
   const { addNotification } = useNotifications();
 
   useEffect(() => {
-    setAmountPaid(charge && charge.id ? charge.amount : '');
+    if (charge && (charge.id || charge.amount)) {
+      setAmountPaid(charge.amount);
+    } else {
+      setAmountPaid('');
+    }
   }, [charge]);
 
   const handleSubmit = async (e) => {

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -31,6 +31,12 @@
   font-size: 1.1rem;
 }
 
+.balance-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .dashboard-review-button {
   margin-top: 8px;
   padding: 6px 12px;

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -19,22 +19,46 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 4px;
+  gap: 8px;
 }
 
-.balance-amount {
-  font-size: 2.5rem;
+.balance-summary {
+  display: flex;
+  gap: 8px;
+}
+
+.balance-card {
+  border-radius: 8px;
+  padding: 8px 12px;
+  min-width: 110px;
+}
+
+.balance-card .amount {
+  font-size: 1.8rem;
   font-weight: bold;
 }
 
-.balance-text {
-  font-size: 1.1rem;
+.balance-card .label {
+  font-size: 0.9rem;
 }
 
-.balance-breakdown {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.balance-card.total {
+  background-color: #e0e0e0;
+}
+
+.balance-card.overdue {
+  background-color: #ffe6e6;
+  color: #b30000;
+}
+
+.balance-card.due-soon {
+  background-color: #fff5e6;
+  color: #e65100;
+}
+
+.balance-card.upcoming {
+  background-color: #e6f2ff;
+  color: #1a73e8;
 }
 
 .dashboard-review-button {


### PR DESCRIPTION
## Summary
- compute balance subtotals and show them on the member dashboard
- disable per-charge payment actions
- adjust payment review form to prefill amounts even without a charge ID
- update MemberDashboard to use a single Mark as Paid button
- update styles and tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871b8ba983c83288a7c396d3c773043