### PR TITLE
Fix notification overlap

### DIFF
--- a/frontend/src/styles/Notifications.css
+++ b/frontend/src/styles/Notifications.css
@@ -11,7 +11,7 @@
 .notification {
   background-color: #4caf50;
   color: #fff;
-  padding: 12px 18px;
+  padding: 14px 36px 14px 18px;
   border-radius: 4px;
   min-width: 200px;
   position: relative;


### PR DESCRIPTION
## Summary
- tweak notification padding so the close button doesn't cover the message

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6871c8a680148328903087b9bb536124