### PR TITLE
Add denial notes to payments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,4 @@ Conclave stores its data in three core tables:
   - `memo`
   - `status`
   - `admin_id` uuid of approving admin
+  - `admin_note` text reason when payment denied

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The application uses three Postgres tables managed through Supabase:
   - `memo` (text)
   - `status` (text)
   - `admin_id` (uuid, approver)
+  - `admin_note` (text, reason for denial)
 
 ## Running the App Locally
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -189,7 +189,8 @@ app.get('/api/payments', auth, async (req, res) => {
       date: p.date,
       memo: p.memo,
       status: p.status,
-      adminId: p.admin_id
+      adminId: p.admin_id,
+      adminNote: p.admin_note
     }))
   );
 });
@@ -208,7 +209,8 @@ app.post('/api/payments', auth, async (req, res) => {
       amount,
       date: date || new Date().toISOString().slice(0, 10),
       memo: memo || '',
-      status: 'Under Review'
+      status: 'Under Review',
+      admin_note: ''
     })
     .select();
   if (error) return res.status(500).json({ error: error.message });
@@ -410,9 +412,11 @@ app.post('/api/admin/payments/:id/approve', auth, adminOnly, async (req, res) =>
 
 app.post('/api/admin/payments/:id/deny', auth, adminOnly, async (req, res) => {
   const id = Number(req.params.id);
+  const { note } = req.body || {};
+  if (!note) return res.status(400).json({ error: 'Missing denial note' });
   const { data, error } = await supabase
     .from('payments')
-    .update({ status: 'Denied', admin_id: req.memberId })
+    .update({ status: 'Denied', admin_id: req.memberId, admin_note: note })
     .eq('id', id)
     .select();
   if (error) return res.status(500).json({ error: error.message });

--- a/backend/test/admin_crud.test.js
+++ b/backend/test/admin_crud.test.js
@@ -145,9 +145,12 @@ test('admin can deny a payment request', async () => {
 
   const rejRes = await fetch(`${baseUrl}/api/admin/payments/${revId}/deny`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${adminToken}` }
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` },
+    body: JSON.stringify({ note: 'Duplicate charge' })
   });
   assert.equal(rejRes.status, 200);
+  const denied = await rejRes.json();
+  assert.equal(denied.payment.admin_note, 'Duplicate charge');
 
   const after = await fetch(`${baseUrl}/api/payments?status=Under%20Review`, {
     headers: { Authorization: `Bearer ${adminToken}` }

--- a/backend/test/supabaseMock.js
+++ b/backend/test/supabaseMock.js
@@ -42,7 +42,8 @@ let payments = [
     date: '2024-04-15',
     memo: 'Dues',
     status: 'Approved',
-    admin_id: profiles[1].id
+    admin_id: profiles[1].id,
+    admin_note: ''
   }
 ];
 let nextPaymentId = 2;
@@ -90,6 +91,7 @@ function from(name) {
           if (name === 'payments') r.id = nextPaymentId++;
           else if (name === 'charges') r.id = nextChargeId++;
         }
+        if (name === 'payments' && !('admin_note' in r)) r.admin_note = '';
         store.push(r);
         return r;
       });

--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -92,8 +92,12 @@ export function useApi() {
       fetchPendingPayments: () => request('/payments?status=Under%20Review'),
       approvePayment: (id) =>
         request(`/admin/payments/${id}/approve`, { method: 'POST' }),
-      denyPayment: (id) =>
-        request(`/admin/payments/${id}/deny`, { method: 'POST' })
+      denyPayment: (id, note) =>
+        request(`/admin/payments/${id}/deny`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ note })
+        })
     }),
     [request]
   );

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -25,7 +25,9 @@ export default function AdminDashboard({ onShowMembers, onShowCharges }) {
   }
 
   async function handleReject(id) {
-    await api.denyPayment(id);
+    const note = window.prompt('Reason for denial?');
+    if (!note) return;
+    await api.denyPayment(id, note);
     setReviews(reviews.filter((rev) => rev.id !== id));
   }
 

--- a/frontend/src/components/PaymentList.js
+++ b/frontend/src/components/PaymentList.js
@@ -14,6 +14,7 @@ export default function PaymentList({ payments }) {
           <th>Paid Date</th>
           <th>Memo</th>
           <th>Status</th>
+          <th>Admin Note</th>
         </tr>
       </thead>
       <tbody>
@@ -23,6 +24,7 @@ export default function PaymentList({ payments }) {
             <td>{new Date(p.date).toLocaleDateString()}</td>
             <td>{p.memo || '-'}</td>
             <td>{p.status}</td>
+            <td>{p.adminNote || '-'}</td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- document new `admin_note` column on the payments table
- surface admin notes on the member dashboard
- require a note when an admin denies a payment
- prompt for a note from the Admin Dashboard
- adjust mocks and tests

## Testing
- `cd backend && npm test --silent`
- `cd frontend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871f8928670832881e463ce21a28856