### PR TITLE
Add confirm dialog with text input for denying payments

### DIFF
--- a/frontend/src/ConfirmDialog.test.js
+++ b/frontend/src/ConfirmDialog.test.js
@@ -33,3 +33,21 @@ test('close button triggers onCancel', async () => {
   await userEvent.click(screen.getByRole('button', { name: /close/i }));
   expect(onCancel).toHaveBeenCalled();
 });
+
+test('input field renders and triggers onInputChange', async () => {
+  const onChange = jest.fn();
+  render(
+    <ConfirmDialog
+      open
+      onConfirm={noop}
+      onCancel={noop}
+      inputLabel="Reason"
+      inputValue=""
+      onInputChange={onChange}
+    />
+  );
+  const input = screen.getByLabelText(/reason/i);
+  expect(input).toBeInTheDocument();
+  await userEvent.type(input, 'abc');
+  expect(onChange).toHaveBeenCalled();
+});

--- a/frontend/src/components/ConfirmDialog.js
+++ b/frontend/src/components/ConfirmDialog.js
@@ -8,9 +8,19 @@ export default function ConfirmDialog({
   confirmText = 'Confirm',
   cancelText = 'Cancel',
   onConfirm,
-  onCancel
+  onCancel,
+  inputLabel,
+  inputValue = '',
+  onInputChange = () => {}
 }) {
   if (!open) return null;
+  const handleConfirm = () => {
+    if (inputLabel) {
+      onConfirm(inputValue);
+    } else {
+      onConfirm();
+    }
+  };
   return (
     <div className="confirm-dialog-overlay" role="dialog" aria-modal="true">
       <div className="confirm-dialog">
@@ -25,9 +35,21 @@ export default function ConfirmDialog({
             ×
           </button>
         </header>
-        <div className="confirm-dialog-body">{children}</div>
+        <div className="confirm-dialog-body">
+          {children}
+          {inputLabel && (
+            <label className="confirm-input">
+              {inputLabel}
+              <input
+                type="text"
+                value={inputValue}
+                onChange={(e) => onInputChange(e.target.value)}
+              />
+            </label>
+          )}
+        </div>
         <div className="confirm-dialog-actions">
-          <button type="button" onClick={onConfirm} className="confirm-button">
+          <button type="button" onClick={handleConfirm} className="confirm-button">
             {confirmText}
           </button>
           <button type="button" onClick={onCancel} className="cancel-button">

--- a/frontend/src/styles/ConfirmDialog.css
+++ b/frontend/src/styles/ConfirmDialog.css
@@ -45,3 +45,14 @@
 .cancel-button {
   padding: 6px 12px;
 }
+
+.confirm-input {
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+}
+
+.confirm-input input {
+  padding: 6px;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- extend `ConfirmDialog` to optionally display an input field
- use the extended dialog when denying payments in `AdminDashboard`
- style input inside confirm dialog
- add tests for new input behaviour

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6871fdcc2b988328aecdf9e24af95e97