### PR TITLE
Fix admin payment review display

### DIFF
--- a/backend/test/supabaseMock.js
+++ b/backend/test/supabaseMock.js
@@ -70,6 +70,16 @@ function from(name) {
           data = data.filter((r) => r[col] === val);
           return q;
         },
+        in(col, vals) {
+          const arr = Array.isArray(vals)
+            ? vals.map((v) => String(v))
+            : String(vals)
+                .replace(/[()']/g, '')
+                .split(',')
+                .map((v) => v.trim());
+          data = data.filter((r) => arr.includes(String(r[col])));
+          return q;
+        },
         not(col, op, val) {
           if (op === 'in') {
             const arr = val


### PR DESCRIPTION
## Summary
- show member names, memo and date in admin payment review table
- update confirmation dialogs to match new fields
- add `in()` helper to Supabase mock for tests

## Testing
- `npm test --silent --prefix backend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6872c9185a1c8328a3d32d2bc3e9a541