### PR TITLE
Show reason required when denying payment

### DIFF
--- a/frontend/src/ConfirmDialog.test.js
+++ b/frontend/src/ConfirmDialog.test.js
@@ -51,3 +51,10 @@ test('input field renders and triggers onInputChange', async () => {
   await userEvent.type(input, 'abc');
   expect(onChange).toHaveBeenCalled();
 });
+
+test('displays error text when provided', () => {
+  render(
+    <ConfirmDialog open onConfirm={noop} onCancel={noop} errorText="Required" />
+  );
+  expect(screen.getByText(/required/i)).toBeInTheDocument();
+});

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -11,6 +11,7 @@ export default function AdminDashboard({ onShowMembers, onShowCharges }) {
   const [reviewToApprove, setReviewToApprove] = useState(null);
   const [reviewToDeny, setReviewToDeny] = useState(null);
   const [denyNote, setDenyNote] = useState('');
+  const [denyError, setDenyError] = useState('');
 
   useEffect(() => {
     async function load() {
@@ -46,14 +47,19 @@ export default function AdminDashboard({ onShowMembers, onShowCharges }) {
   function openDenyDialog(review) {
     setReviewToDeny(review);
     setDenyNote('');
+    setDenyError('');
   }
 
   async function confirmDeny(note) {
     if (!reviewToDeny) return;
-    if (!note) return;
+    if (!note) {
+      setDenyError('Reason is required');
+      return;
+    }
     await api.denyPayment(reviewToDeny.id, note);
     setReviews(reviews.filter((rev) => rev.id !== reviewToDeny.id));
     setReviewToDeny(null);
+    setDenyError('');
   }
 
   return (
@@ -131,10 +137,14 @@ export default function AdminDashboard({ onShowMembers, onShowCharges }) {
         confirmText="Deny"
         cancelText="Cancel"
         onConfirm={confirmDeny}
-        onCancel={() => setReviewToDeny(null)}
+        onCancel={() => {
+          setReviewToDeny(null);
+          setDenyError('');
+        }}
         inputLabel="Reason for denial"
         inputValue={denyNote}
         onInputChange={setDenyNote}
+        errorText={denyError}
       >
         {reviewToDeny && (
           <div className="space-y-1">

--- a/frontend/src/components/ConfirmDialog.js
+++ b/frontend/src/components/ConfirmDialog.js
@@ -11,7 +11,8 @@ export default function ConfirmDialog({
   onCancel,
   inputLabel,
   inputValue = '',
-  onInputChange = () => {}
+  onInputChange = () => {},
+  errorText
 }) {
   if (!open) return null;
   const handleConfirm = () => {
@@ -47,6 +48,7 @@ export default function ConfirmDialog({
               />
             </label>
           )}
+          {errorText && <div className="error">{errorText}</div>}
         </div>
         <div className="confirm-dialog-actions">
           <button type="button" onClick={handleConfirm} className="confirm-button">

--- a/frontend/src/styles/ConfirmDialog.css
+++ b/frontend/src/styles/ConfirmDialog.css
@@ -56,3 +56,8 @@
   padding: 6px;
   font-size: 1rem;
 }
+
+.error {
+  color: red;
+  margin-top: 4px;
+}


### PR DESCRIPTION
## Summary
- add optional `errorText` to `ConfirmDialog`
- display validation message when denying a payment without a reason
- style `.error` message in the dialog
- add unit test for new error text prop

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6872f62bf31483289736db056c2e4952