### PR TITLE
Add create charges page to admin

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -3,7 +3,11 @@ import useApi from '../apiClient';
 import ConfirmDialog from './ConfirmDialog';
 import '../styles/AdminDashboard.css';
 
-export default function AdminDashboard({ onShowMembers, onShowCharges }) {
+export default function AdminDashboard({
+  onCreateCharges,
+  onShowMembers,
+  onShowCharges
+}) {
   const api = useApi();
   const [reviews, setReviews] = useState([]);
   const [members, setMembers] = useState({});
@@ -63,8 +67,12 @@ export default function AdminDashboard({ onShowMembers, onShowCharges }) {
       </header>
       {error && <div className="error">{error}</div>}
       <section className="quick-links">
+        <button className="quick-link" onClick={onCreateCharges}>
+          Create Charges
+          <span className="desc">Assign new charges to members</span>
+        </button>
         <button className="quick-link" onClick={onShowMembers}>
-          Members
+          Manage Members
           <span className="desc">Browse and manage all member accounts</span>
         </button>
         <button className="quick-link" onClick={onShowCharges}>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -96,7 +96,7 @@ function App() {
       pageContent = <MembersList onBack={showAdmin} />;
       break;
     case 'charges':
-      pageContent = <ChargesList />;
+      pageContent = <ChargesList onBack={showAdmin} />;
       break;
     default:
       pageContent = <LoginPage onLogin={showDashboard} />;

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -6,6 +6,7 @@ import MemberDashboard from './MemberDashboard';
 import AdminDashboard from './AdminDashboard';
 import MembersList from './MembersList';
 import ChargesList from './ChargesList';
+import CreateCharges from './CreateCharges';
 import PaymentReviewForm from './PaymentReviewForm';
 import ChargeDetails from './ChargeDetails';
 import AppShell from './AppShell';
@@ -31,6 +32,7 @@ function App() {
   const showAdmin = () => setCurrentPage('admin');
   const showMembersList = () => setCurrentPage('members');
   const showChargesList = () => setCurrentPage('charges');
+  const showCreateCharges = () => setCurrentPage('createCharges');
   const showReview = (charge) => {
     if (charge) {
       setReviewCharge(charge);
@@ -81,10 +83,14 @@ function App() {
     case 'admin':
       pageContent = (
         <AdminDashboard
+          onCreateCharges={showCreateCharges}
           onShowMembers={showMembersList}
           onShowCharges={showChargesList}
         />
       );
+      break;
+    case 'createCharges':
+      pageContent = <CreateCharges onBack={showAdmin} />;
       break;
     case 'members':
       pageContent = <MembersList onBack={showAdmin} />;

--- a/frontend/src/components/ChargesList.js
+++ b/frontend/src/components/ChargesList.js
@@ -15,7 +15,7 @@ const SORT_OPTIONS = [
   { label: 'Amount ↓', value: 'amountDesc' }
 ];
 
-export default function ChargesList() {
+export default function ChargesList({ onBack }) {
   const api = useApi();
   const [charges, setCharges] = useState([]);
   const [members, setMembers] = useState([]);
@@ -60,6 +60,9 @@ export default function ChargesList() {
     <div className="admin-dashboard">
       <header className="admin-dash-header">
         <h1>Charge List</h1>
+        {onBack && (
+          <button onClick={onBack} className="back-button">Back</button>
+        )}
       </header>
       {error && <div className="error">{error}</div>}
       <div className="control-bar">

--- a/frontend/src/components/CreateCharges.js
+++ b/frontend/src/components/CreateCharges.js
@@ -1,0 +1,15 @@
+import '../styles/AdminDashboard.css';
+
+export default function CreateCharges({ onBack }) {
+  return (
+    <div className="admin-dashboard">
+      <header className="admin-dash-header">
+        <h1>Create Charges</h1>
+        {onBack && (
+          <button onClick={onBack} className="back-button">Back</button>
+        )}
+      </header>
+      <p>Charge assignment process coming soon.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `CreateCharges` component
- show a button on the admin dashboard to start charge assignment
- rename members quick link to **Manage Members**
- wire new page into `App`

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6872f7f8e9e08328979884c28a77be2a