### PR TITLE
Add supabase fetch wrapper

### DIFF
--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -1,23 +1,15 @@
-import { useAuth } from './AuthContext';
 import { useCallback, useMemo } from 'react';
+import { authFetch } from './supabaseClient';
 
 // Use the deployed API directly without relying on an environment variable
 const API_BASE = 'https://conclave-app.onrender.com/api';
 
 export function useApi() {
-  const { token } = useAuth();
-
-  const withAuth = useCallback(
-    (headers = {}) =>
-      token ? { ...headers, Authorization: `Bearer ${token}` } : headers,
-    [token]
-  );
 
   const request = useCallback(
     async (path, options = {}, includeAuth = true) => {
-      const headers = includeAuth ? withAuth(options.headers) : options.headers;
-      const opts = { ...options, headers };
-      const res = await fetch(`${API_BASE}${path}`, opts);
+      const fetcher = includeAuth ? authFetch : fetch;
+      const res = await fetcher(`${API_BASE}${path}`, options);
       if (!res.ok) {
         const text = await res.text();
         throw new Error(text || 'API request failed');
@@ -28,7 +20,7 @@ export function useApi() {
         return null;
       }
     },
-    [withAuth]
+    []
   );
 
   return useMemo(

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import '../styles/LoginPage.css';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
-import { supabase } from '../supabaseClient';
+import { supabase, authFetch } from '../supabaseClient';
 
 export default function LoginPage({ onLogin = () => {} }) {
   const [email, setEmail] = useState('');
@@ -26,9 +26,7 @@ export default function LoginPage({ onLogin = () => {} }) {
       }
       const token = data.session.access_token;
       setToken(token);
-      const res = await fetch('/api/member', {
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      const res = await authFetch('/api/member');
       const member = await res.json();
       setUser(member);
       onLogin();

--- a/frontend/src/supabaseClient.js
+++ b/frontend/src/supabaseClient.js
@@ -1,9 +1,43 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl =
-  process.env.REACT_APP_SUPABASE_URL || 'https://tsbyrpuskzsrmjfwckzh.supabase.co';
+  process.env.REACT_APP_SUPABASE_URL ||
+  'https://tsbyrpuskzsrmjfwckzh.supabase.co';
 const supabaseAnon =
   process.env.REACT_APP_SUPABASE_ANON_KEY ||
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzYnlycHVza3pzcm1qZndja3poIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIxOTI0NTEsImV4cCI6MjA2Nzc2ODQ1MX0.yGJn08v2csysvvgMguUlEV87aTVmL6qoD2bkb1x1lYg';
 
-export const supabase = createClient(supabaseUrl, supabaseAnon);
+let supabase;
+
+export async function getValidAccessToken() {
+  if (!supabase) return null;
+  const { data } = await supabase.auth.getSession();
+  let { session } = data || {};
+  if (
+    session &&
+    session.expires_at &&
+    session.expires_at * 1000 - Date.now() < 60000
+  ) {
+    const { data: refreshed } = await supabase.auth.refreshSession();
+    session = refreshed.session || session;
+  }
+  return session ? session.access_token : null;
+}
+
+async function authorizedFetch(input, init = {}) {
+  const token = await getValidAccessToken();
+  init = init || {};
+  init.headers = {
+    ...(init.headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {})
+  };
+  return fetch(input, init);
+}
+
+supabase = createClient(supabaseUrl, supabaseAnon, {
+  global: {
+    fetch: authorizedFetch
+  }
+});
+
+export { supabase, authorizedFetch as authFetch };


### PR DESCRIPTION
## Summary
- add helper to refresh access tokens and wrap fetch calls
- update API client to use the new auth fetch
- update login flow to use the supabase auth fetch

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872fab581808328b212800eb6b261f8