### PR TITLE
Add loading support to DataTable

### DIFF
--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -1,44 +1,69 @@
 import React from 'react';
-import ChargeItem from './ChargeItem';
+import DataTable from './DataTable';
 import '../styles/ChargeList.css';
 
 export default function ChargeList({
-  charges,
+  charges = [],
   onRequestReview = () => {},
   onViewDetails = () => {},
   pendingReviewIds = [],
+  loading = false,
 }) {
   const visible = (charges || []).filter(
     (c) => c.status !== 'Paid' && c.status !== 'Deleted by Admin'
   );
 
-  if (visible.length === 0) {
+  if (!loading && visible.length === 0) {
     return <div className="charge-list-empty">No charges found.</div>;
   }
 
+  const columns = [
+    { header: 'Description', accessor: 'description' },
+    { header: 'Original Amount', accessor: 'amount' },
+    { header: 'Due Date', accessor: 'dueDate' },
+    { header: 'Status', accessor: 'statusDisplay' },
+    { header: 'Partial Amount Paid', accessor: 'partial' }
+  ];
+
+  const rows = visible.map((charge) => {
+    const pending = pendingReviewIds.includes(charge.id);
+    const effectiveStatus = pending ? 'Under Review' : charge.status;
+    const statusDisplay =
+      effectiveStatus === 'Outstanding' ? 'Not Paid' : effectiveStatus;
+    return {
+      id: charge.id,
+      description: charge.description || '-',
+      amount: charge.amount,
+      dueDate: new Date(charge.dueDate).toLocaleDateString(),
+      statusDisplay,
+      partial: charge.partialAmountPaid > 0 ? charge.partialAmountPaid : '',
+      original: charge
+    };
+  });
+
   return (
-    <table className="charge-list">
-      <thead>
-        <tr>
-          <th>Description</th>
-          <th>Original Amount</th>
-          <th>Due Date</th>
-          <th>Status</th>
-          <th>Partial Amount Paid</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {visible.map((charge) => (
-          <ChargeItem
-            key={charge.id || `${charge.status}-${charge.dueDate}`}
-            {...charge}
-            onRequestReview={onRequestReview}
-            onViewDetails={onViewDetails}
-            pending={pendingReviewIds.includes(charge.id)}
-          />
-        ))}
-      </tbody>
-    </table>
+    <DataTable
+      loading={loading}
+      columns={columns}
+      data={rows}
+      renderActions={(row) => (
+        <div className="flex space-x-2">
+          <button
+            type="button"
+            onClick={() =>
+              onViewDetails({
+                id: row.original.id,
+                status: row.original.status,
+                amount: row.original.amount,
+                dueDate: row.original.dueDate
+              })
+            }
+            className="px-3 py-1 bg-gray-200 text-gray-800 rounded"
+          >
+            Details
+          </button>
+        </div>
+      )}
+    />
   );
 }

--- a/frontend/src/components/ChargesList.js
+++ b/frontend/src/components/ChargesList.js
@@ -20,6 +20,7 @@ export default function ChargesList({ onBack }) {
   const [charges, setCharges] = useState([]);
   const [members, setMembers] = useState([]);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState('dueAsc');
   const [statusFilter, setStatusFilter] = useState([]);
@@ -27,6 +28,7 @@ export default function ChargesList({ onBack }) {
 
   useEffect(() => {
     async function load() {
+      setLoading(true);
       try {
         const [c, m] = await Promise.all([
           api.fetchAllCharges(search),
@@ -36,6 +38,8 @@ export default function ChargesList({ onBack }) {
         setMembers(m || []);
       } catch (e) {
         setError(e.message);
+      } finally {
+        setLoading(false);
       }
     }
     load();
@@ -78,6 +82,7 @@ export default function ChargesList({ onBack }) {
         onChangeTags={setTagFilter}
       />
       <DataTable
+        loading={loading}
         columns={[
           { header: 'Member', accessor: 'memberName' },
           { header: 'Description', accessor: 'description' },

--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -1,27 +1,38 @@
 import React from 'react';
 import '../styles/AdminDashboard.css';
-
-export default function DataTable({ columns = [], data = [], renderActions }) {
+export default function DataTable({
+  columns = [],
+  data = [],
+  renderActions,
+  loading = false
+}) {
   return (
-    <table className="admin-table">
-      <thead>
-        <tr>
-          {columns.map((c) => (
-            <th key={c.accessor}>{c.header}</th>
-          ))}
-          {renderActions && <th>Actions</th>}
-        </tr>
-      </thead>
-      <tbody>
-        {data.map((row) => (
-          <tr key={row.id || JSON.stringify(row)}>
+    <div className="data-table-wrapper">
+      {loading && (
+        <div className="loading-overlay">
+          <span className="spinner" aria-label="loading" />
+        </div>
+      )}
+      <table className="admin-table">
+        <thead>
+          <tr>
             {columns.map((c) => (
-              <td key={c.accessor}>{row[c.accessor]}</td>
+              <th key={c.accessor}>{c.header}</th>
             ))}
-            {renderActions && <td>{renderActions(row)}</td>}
+            {renderActions && <th>Actions</th>}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr key={row.id || JSON.stringify(row)}>
+              {columns.map((c) => (
+                <td key={c.accessor}>{row[c.accessor]}</td>
+              ))}
+              {renderActions && <td>{renderActions(row)}</td>}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/frontend/src/components/MembersList.js
+++ b/frontend/src/components/MembersList.js
@@ -19,6 +19,7 @@ export default function MembersList({ onBack }) {
   const api = useApi();
   const [members, setMembers] = useState([]);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState('nameAsc');
   const [statusFilter, setStatusFilter] = useState([]);
@@ -26,11 +27,14 @@ export default function MembersList({ onBack }) {
 
   useEffect(() => {
     async function load() {
+      setLoading(true);
       try {
         const data = await api.fetchMembers(search);
         setMembers(data || []);
       } catch (e) {
         setError(e.message);
+      } finally {
+        setLoading(false);
       }
     }
     load();
@@ -58,6 +62,7 @@ export default function MembersList({ onBack }) {
         onChangeTags={setTagFilter}
       />
       <DataTable
+        loading={loading}
         columns={[
           { header: 'Name', accessor: 'name' },
           { header: 'Email', accessor: 'email' },

--- a/frontend/src/components/PaymentList.js
+++ b/frontend/src/components/PaymentList.js
@@ -1,33 +1,26 @@
 import React from 'react';
+import DataTable from './DataTable';
 import '../styles/PaymentList.css';
 
-export default function PaymentList({ payments }) {
-  if (!payments || payments.length === 0) {
+export default function PaymentList({ payments = [], loading = false }) {
+  if (!loading && payments.length === 0) {
     return <div className="payment-list-empty">No payments found.</div>;
   }
 
-  return (
-    <table className="payment-list">
-      <thead>
-        <tr>
-          <th>Amount Paid</th>
-          <th>Paid Date</th>
-          <th>Memo</th>
-          <th>Status</th>
-          <th>Admin Note</th>
-        </tr>
-      </thead>
-      <tbody>
-        {payments.map((p) => (
-          <tr key={p.id || `${p.amount}-${p.date}`}>
-            <td>{p.amount}</td>
-            <td>{new Date(p.date).toLocaleDateString()}</td>
-            <td>{p.memo || '-'}</td>
-            <td>{p.status}</td>
-            <td>{p.adminNote || '-'}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
+  const columns = [
+    { header: 'Amount Paid', accessor: 'amount' },
+    { header: 'Paid Date', accessor: 'paidDate' },
+    { header: 'Memo', accessor: 'memo' },
+    { header: 'Status', accessor: 'status' },
+    { header: 'Admin Note', accessor: 'adminNote' }
+  ];
+
+  const rows = payments.map((p) => ({
+    ...p,
+    paidDate: new Date(p.date).toLocaleDateString(),
+    memo: p.memo || '-',
+    adminNote: p.adminNote || '-'
+  }));
+
+  return <DataTable columns={columns} data={rows} loading={loading} />;
 }

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -64,3 +64,38 @@
   display: flex;
   gap: 4px;
 }
+
+/* DataTable loading overlay */
+.data-table-wrapper {
+  position: relative;
+}
+
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.spinner {
+  border: 2px solid #ccc;
+  border-top: 2px solid #333;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- show a spinner while data loads in DataTable
- style loading overlay
- use DataTable for admin payment reviews, member charges, payments and lists

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6872fca809488328be93a9e1be7312b5