### PR TITLE
Add member creation page

### DIFF
--- a/frontend/src/AddMember.test.js
+++ b/frontend/src/AddMember.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddMember from './components/AddMember';
+import { AuthProvider } from './AuthContext';
+
+function setupLocalStorage() {
+  localStorage.setItem('authToken', 'token');
+  localStorage.setItem('authUser', JSON.stringify({ id: 1 }));
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+  localStorage.clear();
+});
+
+test('requires fields before submitting', async () => {
+  setupLocalStorage();
+  render(
+    <AuthProvider>
+      <AddMember />
+    </AuthProvider>
+  );
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(
+    await screen.findByText(/email, password and name are required/i)
+  ).toBeInTheDocument();
+});
+
+test('successful submit calls API', async () => {
+  setupLocalStorage();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: async () => ({ id: 1 }) })
+  );
+  render(
+    <AuthProvider>
+      <AddMember />
+    </AuthProvider>
+  );
+  await userEvent.type(screen.getByLabelText(/email/i), 'user@test.com');
+  await userEvent.type(screen.getByLabelText(/^password/i), 'pass');
+  await userEvent.type(screen.getByLabelText(/display name/i), 'User');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  await screen.findByText(/member created/i);
+  expect(global.fetch).toHaveBeenCalled();
+});

--- a/frontend/src/components/AddMember.js
+++ b/frontend/src/components/AddMember.js
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import useApi from '../apiClient';
+import '../styles/AddMember.css';
+
+export default function AddMember({ onCancel }) {
+  const api = useApi();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    if (!email || !password || !name) {
+      setError('Email, password and name are required');
+      return;
+    }
+    try {
+      await api.createMember({ email, password, name, isAdmin });
+      setMessage('Member created');
+      setEmail('');
+      setPassword('');
+      setName('');
+      setIsAdmin(false);
+      if (onCancel) onCancel();
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="add-member-page">
+      <h1>Add Member</h1>
+      <form onSubmit={handleSubmit} className="add-member-form">
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        <label>
+          Display Name
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+        <label className="checkbox">
+          <input
+            type="checkbox"
+            checked={isAdmin}
+            onChange={(e) => setIsAdmin(e.target.checked)}
+          />{' '}
+          Admin
+        </label>
+        {error && <div className="error">{error}</div>}
+        {message && <div className="success">{message}</div>}
+        <div className="form-actions">
+          <button type="submit">Submit</button>
+          {onCancel && (
+            <button type="button" onClick={onCancel} className="back-button">
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -79,7 +79,9 @@ export default function AdminDashboard({
         </button>
         <button className="quick-link" onClick={onShowMembers}>
           Manage Members
-          <span className="desc">Browse and manage all member accounts</span>
+          <span className="desc">
+            Add, browse, and manage all member accounts
+          </span>
         </button>
         <button className="quick-link" onClick={onShowCharges}>
           Charges

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -7,6 +7,7 @@ import AdminDashboard from './AdminDashboard';
 import MembersList from './MembersList';
 import ChargesList from './ChargesList';
 import CreateCharges from './CreateCharges';
+import AddMember from './AddMember';
 import PaymentReviewForm from './PaymentReviewForm';
 import ChargeDetails from './ChargeDetails';
 import AppShell from './AppShell';
@@ -33,6 +34,7 @@ function App() {
   const showMembersList = () => setCurrentPage('members');
   const showChargesList = () => setCurrentPage('charges');
   const showCreateCharges = () => setCurrentPage('createCharges');
+  const showAddMember = () => setCurrentPage('addMember');
   const showReview = (charge) => {
     if (charge) {
       setReviewCharge(charge);
@@ -93,7 +95,12 @@ function App() {
       pageContent = <CreateCharges onBack={showAdmin} />;
       break;
     case 'members':
-      pageContent = <MembersList onBack={showAdmin} />;
+      pageContent = (
+        <MembersList onBack={showAdmin} onAdd={showAddMember} />
+      );
+      break;
+    case 'addMember':
+      pageContent = <AddMember onCancel={showMembersList} />;
       break;
     case 'charges':
       pageContent = <ChargesList onBack={showAdmin} />;

--- a/frontend/src/components/MembersList.js
+++ b/frontend/src/components/MembersList.js
@@ -15,7 +15,7 @@ const SORT_OPTIONS = [
   { label: 'Amount Owed', value: 'amountDesc' }
 ];
 
-export default function MembersList({ onBack }) {
+export default function MembersList({ onBack, onAdd }) {
   const api = useApi();
   const [members, setMembers] = useState([]);
   const [error, setError] = useState('');
@@ -40,9 +40,14 @@ export default function MembersList({ onBack }) {
     <div className="admin-dashboard">
       <header className="admin-dash-header">
         <h1>Members List</h1>
-        {onBack && (
-          <button onClick={onBack} className="back-button">Back</button>
-        )}
+        <div className="action-buttons">
+          {onAdd && (
+            <button onClick={onAdd} className="add-button">Add Member</button>
+          )}
+          {onBack && (
+            <button onClick={onBack} className="back-button">Back</button>
+          )}
+        </div>
       </header>
       {error && <div className="error">{error}</div>}
       <div className="control-bar">

--- a/frontend/src/styles/AddMember.css
+++ b/frontend/src/styles/AddMember.css
@@ -1,0 +1,45 @@
+.add-member-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+}
+
+.add-member-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 300px;
+}
+
+.add-member-form label {
+  display: flex;
+  flex-direction: column;
+  font-weight: bold;
+}
+
+.add-member-form input[type="text"],
+.add-member-form input[type="email"],
+.add-member-form input[type="password"] {
+  padding: 8px;
+  font-size: 1rem;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  font-weight: normal;
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.error {
+  color: red;
+}
+
+.success {
+  color: green;
+}


### PR DESCRIPTION
## Summary
- update admin dashboard wording for Manage Members
- add ability to add members from the Members List page
- implement AddMember page and styling
- update app navigation
- test AddMember form validation

## Testing
- `npm --prefix frontend test --silent`
- `npm --prefix backend test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872fedcf96483289cc2771f84d9275d