### PR TITLE
Support member search by status

### DIFF
--- a/backend/routes/members.js
+++ b/backend/routes/members.js
@@ -8,7 +8,7 @@ router.get('/', async (req, res) => {
 
   if (search) {
     query = query.or(
-      `name.ilike.%${search}%,email.ilike.%${search}%`
+      `name.ilike.%${search}%,email.ilike.%${search}%,status.ilike.%${search}%`
     );
   }
 

--- a/backend/test/index.test.js
+++ b/backend/test/index.test.js
@@ -230,3 +230,10 @@ test('payment approval updates member charges', async () => {
   assert.equal(c1.partialAmountPaid, 0);
   assert.equal(c3.status, 'Paid');
 });
+
+test('search members by status', async () => {
+  const res = await fetch(`${baseUrl}/api/members?search=Active`);
+  assert.equal(res.status, 200);
+  const members = await res.json();
+  assert.equal(members.length, 2);
+});


### PR DESCRIPTION
## Summary
- allow searching members by status
- test status search through `/api/members`

## Testing
- `npm run test:coverage` in `frontend`
- `npm run test:coverage` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68730c1427548328a3842c0381680ddc