### PR TITLE
Member dashboard renders before data loads

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -104,6 +104,7 @@ test('dashboard review button opens form with charge data', async () => {
   );
   await userEvent.click(screen.getByRole('button', { name: /dashboard/i }));
   const reviewButton = await screen.findByRole('button', { name: /mark as paid/i });
+  await screen.findAllByText('$200');
   await userEvent.click(reviewButton);
   const heading = await screen.findByRole('heading', { name: /payment review/i });
   expect(heading).toBeInTheDocument();
@@ -118,6 +119,7 @@ test('dashboard tile review button opens form', async () => {
   );
   await userEvent.click(screen.getByRole('button', { name: /dashboard/i }));
   const button = await screen.findByTestId('dashboard-review-button');
+  await screen.findAllByText('$200');
   await userEvent.click(button);
   const heading = await screen.findByRole('heading', { name: /payment review/i });
   expect(heading).toBeInTheDocument();

--- a/frontend/src/MemberDashboard.test.js
+++ b/frontend/src/MemberDashboard.test.js
@@ -46,7 +46,8 @@ test('renders dashboard sections', async () => {
     name: /recent payments/i
   });
   expect(paymentsHeading).toBeInTheDocument();
-  const total = screen.getByTestId('total-balance');
+  const total = await screen.findByTestId('total-balance');
+  await screen.findAllByText('$200');
   expect(total).toHaveTextContent('$200');
   expect(screen.getByTestId('overdue-balance')).toHaveTextContent('$200');
 });
@@ -69,7 +70,7 @@ test('dashboard payment review button triggers callback', async () => {
       <MemberDashboard onRequestReview={onRequestReview} />
     </AuthProvider>
   );
-  await screen.findByTestId('total-balance');
+  await screen.findAllByText('$200');
   const button = screen.getByTestId('dashboard-review-button');
   await userEvent.click(button);
   expect(onRequestReview).toHaveBeenCalled();
@@ -147,7 +148,9 @@ test('partial amount paid displayed for charges', async () => {
   );
   const header = await screen.findByText(/partial amount paid/i);
   const table = header.closest('table');
-  const row = within(table).getAllByRole('row')[1];
+  await screen.findByText('25');
+  const rows = within(table).getAllByRole('row');
+  const row = rows[1];
   const cells = within(row).getAllByRole('cell');
   expect(cells[4]).toHaveTextContent('25');
 });
@@ -178,6 +181,7 @@ test('outstanding charges are sorted oldest first', async () => {
   );
   const header = await screen.findByText(/due date/i);
   const table = header.closest('table');
+  await screen.findByText('20');
   const rows = within(table).getAllByRole('row').slice(1);
   expect(rows[0]).toHaveTextContent('20');
   expect(rows[1]).toHaveTextContent('10');

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -46,9 +46,6 @@ export default function MemberDashboard({
 
 
   // Render
-  if (loading) {
-    return <div>Loading…</div>;
-  }
 
   const mergedCharges = chargeData.map((c) =>
     pendingReviewIds.includes(c.id) ? { ...c, status: 'Under Review' } : c
@@ -127,7 +124,7 @@ export default function MemberDashboard({
           type="button"
           className="dashboard-review-button"
           data-testid="dashboard-review-button"
-          disabled={totalBalance === 0}
+          disabled={loading || totalBalance === 0}
           onClick={() => onRequestReview({ amount: totalBalance })}
         >
           Mark as Paid
@@ -140,12 +137,13 @@ export default function MemberDashboard({
           charges={sortedOutstanding}
           onViewDetails={onViewDetails}
           pendingReviewIds={pendingReviewIds}
+          loading={loading}
         />
       </section>
 
       <section>
         <h2>Recent Payments</h2>
-        <PaymentList payments={sortedPayments} />
+        <PaymentList payments={sortedPayments} loading={loading} />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- always render `MemberDashboard` layout
- disable Mark as Paid while loading
- pass loading flag to `ChargeList` and `PaymentList`
- update tests for new loading behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687300c9814483289e8ada1eb4d37369