### PR TITLE
Remove "Not Paid" translation for outstanding charges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Conclave serves as the Lambda Delta chapter's platform for:
 - Submit a payment review request if a Zelle payment has not been recorded
   - Include memo/note with transaction details
 - Track the status of each charge: `Delinquent`, `Outstanding`, `Under Review`, or `Paid`
+  - Status names are displayed exactly as stored (e.g., unpaid charges show `Outstanding`)
 
 ### Admin Functionality
 - View and search the member directory

--- a/frontend/src/components/ChargeItem.js
+++ b/frontend/src/components/ChargeItem.js
@@ -10,8 +10,7 @@ export default function ChargeItem({
   pending = false,
 }) {
   const effectiveStatus = pending ? 'Under Review' : status;
-  const displayStatus =
-    effectiveStatus === 'Outstanding' ? 'Not Paid' : effectiveStatus;
+  const displayStatus = effectiveStatus;
   return (
     <tr className="charge-item">
       <td>{description || '-'}</td>

--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -28,8 +28,7 @@ export default function ChargeList({
   const rows = visible.map((charge) => {
     const pending = pendingReviewIds.includes(charge.id);
     const effectiveStatus = pending ? 'Under Review' : charge.status;
-    const statusDisplay =
-      effectiveStatus === 'Outstanding' ? 'Not Paid' : effectiveStatus;
+    const statusDisplay = effectiveStatus;
     return {
       id: charge.id,
       description: charge.description || '-',


### PR DESCRIPTION
## Summary
- stop translating "Outstanding" to "Not Paid" in ChargeItem and ChargeList
- document that statuses are shown as stored

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68730d3263408328b514c18873697351