### PR TITLE
Remove redundant create charges button

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -6,8 +6,7 @@ import '../styles/AdminDashboard.css';
 
 export default function AdminDashboard({
   onCreateCharges,
-  onShowMembers,
-  onShowCharges
+  onShowMembers
 }) {
   const api = useApi();
   const [reviews, setReviews] = useState([]);
@@ -85,10 +84,6 @@ export default function AdminDashboard({
         <button className="quick-link" onClick={onShowMembers}>
           Manage Members
           <span className="desc">Create, browse and manage all member accounts</span>
-        </button>
-        <button className="quick-link" onClick={onShowCharges}>
-          Create Charges
-          <span className="desc">Add new charges and manage existing</span>
         </button>
       </section>
       <section>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -85,7 +85,6 @@ function App() {
         <AdminDashboard
           onCreateCharges={showCreateCharges}
           onShowMembers={showMembersList}
-          onShowCharges={showCreateCharges}
         />
       );
       break;


### PR DESCRIPTION
## Summary
- strip the unused `onShowCharges` callback
- delete the extra **Create Charges** button in the admin dashboard

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687310c7fdac8328a51e9285beeb6ef5