### PR TITLE
Implement charge creation wizard

### DIFF
--- a/frontend/src/components/CreateCharges.js
+++ b/frontend/src/components/CreateCharges.js
@@ -1,26 +1,283 @@
-import { useState } from 'react';
-import ChargesList from './ChargesList';
-import '../styles/AdminDashboard.css';
+import { useEffect, useState } from 'react';
+import useApi from '../apiClient';
+import SearchBar from './SearchBar';
+import FilterMenu from './FilterMenu';
+import ConfirmDialog from './ConfirmDialog';
+import { useNotifications } from '../NotificationContext';
+import '../styles/CreateCharges.css';
+
+const STATUS_OPTIONS = ['Active', 'Alumni', 'Inactive', 'Suspended', 'Expelled'];
 
 export default function CreateCharges({ onBack }) {
-  const [showForm, setShowForm] = useState(false);
+  const api = useApi();
+  const { addNotification } = useNotifications();
+  const [step, setStep] = useState(1);
+  const [description, setDescription] = useState('');
+  const [amount, setAmount] = useState('');
+  const [dueDate, setDueDate] = useState(() => {
+    const dt = new Date();
+    dt.setDate(dt.getDate() + 30);
+    return dt.toISOString().slice(0, 10);
+  });
+  const [members, setMembers] = useState([]);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState([]);
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [error, setError] = useState('');
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [loadingMembers, setLoadingMembers] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await api.fetchMembers('');
+        setMembers(data || []);
+      } catch (e) {
+        setError(e.message);
+      } finally {
+        setLoadingMembers(false);
+      }
+    }
+    load();
+  }, [api]);
+
+  const filteredMembers = members
+    .filter((m) =>
+      !search ? true :
+      m.name.toLowerCase().includes(search.toLowerCase()) ||
+      m.email.toLowerCase().includes(search.toLowerCase())
+    )
+    .filter((m) =>
+      statusFilter.length ? statusFilter.includes(m.status) : true
+    );
+
+  const toggleSelect = (id) => {
+    setSelectedIds((ids) =>
+      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id]
+    );
+  };
+
+  const selectAllMatching = () => {
+    setSelectedIds(Array.from(new Set([...selectedIds, ...filteredMembers.map((m) => m.id)])));
+  };
+
+  const nextDisabled = () => {
+    if (step === 1) {
+      return !description.trim() || !amount || Number(amount) <= 0 || !dueDate;
+    }
+    if (step === 2) {
+      return selectedIds.length === 0;
+    }
+    return false;
+  };
+
+  const handleNext = () => {
+    if (nextDisabled()) {
+      setError('Please complete all required fields');
+      return;
+    }
+    setError('');
+    setStep((s) => s + 1);
+  };
+
+  const handleBack = () => {
+    if (step === 1) {
+      onBack && onBack();
+    } else {
+      setStep((s) => s - 1);
+    }
+  };
+
+  const submit = async () => {
+    setShowConfirm(false);
+    try {
+      for (const id of selectedIds) {
+        await api.createCharge({
+          memberId: id,
+          amount: Number(amount),
+          dueDate,
+          description,
+          status: 'Outstanding'
+        });
+      }
+      addNotification(`Charges successfully assigned to ${selectedIds.length} members.`);
+      onBack && onBack();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
   return (
-    <div className="admin-dashboard">
-      <header className="admin-dash-header">
+    <div className="create-charges-page">
+      <header>
         <h1>Create Charges</h1>
-        {onBack && (
-          <button onClick={onBack} className="back-button">Back</button>
-        )}
+        <div className="step-indicator">Step {step} of 3</div>
       </header>
-      <div>
-        <button onClick={() => setShowForm(!showForm)}>Add Charge</button>
-      </div>
-      {showForm && (
-        <div>
-          <em>Charge creation form coming soon...</em>
+      {error && <div className="error">{error}</div>}
+      {step === 1 && (
+        <form className="charge-form" onSubmit={(e) => e.preventDefault()}>
+          <label>
+            Description
+            <textarea
+              maxLength="255"
+              placeholder="e.g. Monthly Subscription Fee"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </label>
+          <label>
+            Amount
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
+          </label>
+          <label>
+            Due Date
+            <input
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </label>
+        </form>
+      )}
+      {step === 2 && (
+        <div className="select-assignees">
+          <div className="filters">
+            <SearchBar value={search} onChange={setSearch} placeholder="Search members" />
+            <FilterMenu
+              statusOptions={STATUS_OPTIONS}
+              selectedStatuses={statusFilter}
+              tagOptions={[]}
+              selectedTags={[]}
+              onChangeStatuses={setStatusFilter}
+              onChangeTags={() => {}}
+            />
+            <button type="button" onClick={selectAllMatching} disabled={filteredMembers.length === 0}>
+              Select All Matching
+            </button>
+            <div className="selected-count">
+              {selectedIds.length} of {members.length} members selected
+            </div>
+          </div>
+          <div className="member-list">
+            {loadingMembers ? (
+              <div>Loading...</div>
+            ) : (
+              <table className="admin-table">
+                <thead>
+                  <tr>
+                    <th>
+                      <input
+                        type="checkbox"
+                        checked={filteredMembers.length > 0 && filteredMembers.every((m) => selectedIds.includes(m.id))}
+                        onChange={() => {
+                          const all = filteredMembers.map((m) => m.id);
+                          const allSelected = all.every((id) => selectedIds.includes(id));
+                          if (allSelected) {
+                            setSelectedIds(selectedIds.filter((id) => !all.includes(id)));
+                          } else {
+                            setSelectedIds(Array.from(new Set([...selectedIds, ...all])));
+                          }
+                        }}
+                      />
+                    </th>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredMembers.map((m) => (
+                    <tr key={m.id}>
+                      <td>
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.includes(m.id)}
+                          onChange={() => toggleSelect(m.id)}
+                        />
+                      </td>
+                      <td>{m.name}</td>
+                      <td>{m.email}</td>
+                      <td>{m.status}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
         </div>
       )}
-      <ChargesList />
+      {step === 3 && (
+        <div className="review-step">
+          <div className="summary-card">
+            <div>
+              <strong>Description:</strong> {description}
+            </div>
+            <div>
+              <strong>Amount:</strong> {amount}
+            </div>
+            <div>
+              <strong>Due Date:</strong> {dueDate}
+            </div>
+            <div>
+              <strong>Total Members:</strong> {selectedIds.length}
+            </div>
+          </div>
+          <details>
+            <summary>View Members</summary>
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {members
+                  .filter((m) => selectedIds.includes(m.id))
+                  .map((m) => (
+                    <tr key={m.id}>
+                      <td>{m.name}</td>
+                      <td>{m.email}</td>
+                      <td>{m.status}</td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </details>
+        </div>
+      )}
+      <div className="wizard-footer">
+        <button type="button" onClick={handleBack}>Back</button>
+        {step < 3 && (
+          <button type="button" onClick={handleNext} disabled={nextDisabled()}>
+            Next
+          </button>
+        )}
+        {step === 3 && (
+          <button type="button" onClick={() => setShowConfirm(true)}>
+            Confirm
+          </button>
+        )}
+      </div>
+      <ConfirmDialog
+        open={showConfirm}
+        title="Confirm Charges"
+        confirmText="Confirm"
+        cancelText="Cancel"
+        onConfirm={submit}
+        onCancel={() => setShowConfirm(false)}
+      >
+        <p>
+          Assign charge "{description}" of ${amount} due {dueDate} to {selectedIds.length} members?
+        </p>
+      </ConfirmDialog>
     </div>
   );
 }

--- a/frontend/src/styles/CreateCharges.css
+++ b/frontend/src/styles/CreateCharges.css
@@ -1,0 +1,55 @@
+.create-charges-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+}
+
+.step-indicator {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.charge-form {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  gap: 12px;
+  max-width: 500px;
+}
+
+.charge-form label {
+  display: contents;
+}
+
+.charge-form textarea,
+.charge-form input {
+  padding: 8px;
+  font-size: 1rem;
+}
+
+.select-assignees .filters {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.wizard-footer {
+  display: flex;
+  gap: 8px;
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  padding: 10px 0;
+}
+
+.summary-card {
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.error {
+  color: red;
+}


### PR DESCRIPTION
## Summary
- implement multi-step charge creation wizard for admins
- style the wizard with new CreateCharges.css

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68731c23fa948328b95f57d6e17de559