### PR TITLE
Fix Supabase login recursion

### DIFF
--- a/frontend/src/supabaseClient.js
+++ b/frontend/src/supabaseClient.js
@@ -7,7 +7,7 @@ const supabaseAnon =
   process.env.REACT_APP_SUPABASE_ANON_KEY ||
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzYnlycHVza3pzcm1qZndja3poIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIxOTI0NTEsImV4cCI6MjA2Nzc2ODQ1MX0.yGJn08v2csysvvgMguUlEV87aTVmL6qoD2bkb1x1lYg';
 
-let supabase;
+export const supabase = createClient(supabaseUrl, supabaseAnon);
 
 export async function getValidAccessToken() {
   if (!supabase) return null;
@@ -34,10 +34,4 @@ async function authorizedFetch(input, init = {}) {
   return fetch(input, init);
 }
 
-supabase = createClient(supabaseUrl, supabaseAnon, {
-  global: {
-    fetch: authorizedFetch
-  }
-});
-
-export { supabase, authorizedFetch as authFetch };
+export { authorizedFetch as authFetch };


### PR DESCRIPTION
## Summary
- initialize Supabase client without overriding the fetch implementation
- keep `authFetch` for authenticated backend calls

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68731e5c4c188328b98de9eb2beba6b1