### PR TITLE
Add Supabase member creation function docs

### DIFF
--- a/backend/test/supabaseMock.js
+++ b/backend/test/supabaseMock.js
@@ -192,17 +192,20 @@ const supabaseAdmin = {
       return { data: null, error: new Error('Unknown function') };
     }
     const id = crypto.randomUUID();
+
+    // emulate the SQL procedure which inserts into auth.users and profiles
     profiles.push({
       id,
       email: params.p_email,
       password: 'password',
-      display_name: params.p_full_name,
+      name: params.p_full_name,
       is_admin: params.p_is_admin,
       status: params.p_status,
       initiation_date: new Date().toISOString().slice(0, 10),
       amount_owed: 0,
       tags: []
     });
+
     return { data: id, error: null };
   }
 };


### PR DESCRIPTION
## Summary
- document the `create_user_with_profile` stored procedure and service role key requirements
- update the Supabase test mock so `create_user_with_profile` matches real data

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687328ee54a8832880c38777979e19a8