### PR TITLE
Rename CreateCharges to ManageCharges

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -5,7 +5,7 @@ import DataTable from './DataTable';
 import '../styles/AdminDashboard.css';
 
 export default function AdminDashboard({
-  onCreateCharges,
+  onManageCharges,
   onShowMembers,
   onShowCharges
 }) {
@@ -78,7 +78,7 @@ export default function AdminDashboard({
       </header>
       {error && <div className="error">{error}</div>}
       <section className="quick-links">
-        <button className="quick-link" onClick={onCreateCharges}>
+        <button className="quick-link" onClick={onManageCharges}>
           Manage Charges
           <span className="desc">Create, update, or delete charges for members</span>
         </button>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -6,7 +6,7 @@ import MemberDashboard from './MemberDashboard';
 import AdminDashboard from './AdminDashboard';
 import MembersList from './MembersList';
 import ChargesList from './ChargesList';
-import CreateCharges from './CreateCharges';
+import ManageCharges from './ManageCharges';
 import AddMember from './AddMember';
 import PaymentReviewForm from './PaymentReviewForm';
 import ChargeDetails from './ChargeDetails';
@@ -33,7 +33,7 @@ function App() {
   const showAdmin = () => setCurrentPage('admin');
   const showMembersList = () => setCurrentPage('members');
   const showChargesList = () => setCurrentPage('charges');
-  const showCreateCharges = () => setCurrentPage('createCharges');
+  const showManageCharges = () => setCurrentPage('manageCharges');
   const showAddMember = () => setCurrentPage('addMember');
   const showReview = (charge) => {
     if (charge) {
@@ -85,14 +85,14 @@ function App() {
     case 'admin':
       pageContent = (
         <AdminDashboard
-          onCreateCharges={showCreateCharges}
+          onManageCharges={showManageCharges}
           onShowMembers={showMembersList}
           onShowCharges={showChargesList}
         />
       );
       break;
-    case 'createCharges':
-      pageContent = <CreateCharges onBack={showAdmin} />;
+    case 'manageCharges':
+      pageContent = <ManageCharges onBack={showAdmin} />;
       break;
     case 'members':
       pageContent = (
@@ -105,8 +105,8 @@ function App() {
     case 'charges':
       pageContent = <ChargesList onBack={showAdmin} />;
       break;
-    case 'createCharges':
-      pageContent = <CreateCharges onBack={showAdmin} />;
+    case 'manageCharges':
+      pageContent = <ManageCharges onBack={showAdmin} />;
       break;
     default:
       pageContent = <LoginPage onLogin={showDashboard} />;

--- a/frontend/src/components/ManageCharges.js
+++ b/frontend/src/components/ManageCharges.js
@@ -4,11 +4,11 @@ import SearchBar from './SearchBar';
 import FilterMenu from './FilterMenu';
 import ConfirmDialog from './ConfirmDialog';
 import { useNotifications } from '../NotificationContext';
-import '../styles/CreateCharges.css';
+import '../styles/ManageCharges.css';
 
 const STATUS_OPTIONS = ['Active', 'Alumni', 'Inactive', 'Suspended', 'Expelled'];
 
-export default function CreateCharges({ onBack }) {
+export default function ManageCharges({ onBack }) {
   const api = useApi();
   const { addNotification } = useNotifications();
   const [step, setStep] = useState(1);
@@ -108,9 +108,9 @@ export default function CreateCharges({ onBack }) {
   };
 
   return (
-    <div className="create-charges-page">
+    <div className="manage-charges-page">
       <header>
-        <h1>Create Charges</h1>
+        <h1>Manage Charges</h1>
         <div className="step-indicator">Step {step} of 3</div>
       </header>
       {error && <div className="error">{error}</div>}
@@ -262,14 +262,14 @@ export default function CreateCharges({ onBack }) {
         )}
         {step === 3 && (
           <button type="button" onClick={() => setShowConfirm(true)}>
-            Confirm
+            Create Charge
           </button>
         )}
       </div>
       <ConfirmDialog
         open={showConfirm}
         title="Confirm Charges"
-        confirmText="Confirm"
+        confirmText="Create Charge"
         cancelText="Cancel"
         onConfirm={submit}
         onCancel={() => setShowConfirm(false)}

--- a/frontend/src/styles/ManageCharges.css
+++ b/frontend/src/styles/ManageCharges.css
@@ -1,4 +1,4 @@
-.create-charges-page {
+.manage-charges-page {
   display: flex;
   flex-direction: column;
   gap: 20px;


### PR DESCRIPTION
## Summary
- rename `CreateCharges` page to `ManageCharges`
- rename quick link prop & update references
- change page heading to **Manage Charges**
- update final button text to **Create Charge**

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687329cfddd48328ae4b368d04750f72