### PR TITLE
Compute member balances from charges

### DIFF
--- a/backend/test/index.test.js
+++ b/backend/test/index.test.js
@@ -237,3 +237,22 @@ test('search members by status', async () => {
   const members = await res.json();
   assert.equal(members.length, 2);
 });
+
+test('admin members endpoint returns aggregated balances', async () => {
+  const login = await fetch(`${baseUrl}/api/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'admin@example.com', password: 'admin' })
+  });
+  const { token: adminToken } = await login.json();
+
+  const res = await fetch(`${baseUrl}/api/admin/members`, {
+    headers: { Authorization: `Bearer ${adminToken}` }
+  });
+  assert.equal(res.status, 200);
+  const members = await res.json();
+  const member = members.find(m => m.email === 'member@example.com');
+  const admin = members.find(m => m.email === 'admin@example.com');
+  assert.equal(member.amountOwed, 0);
+  assert.equal(admin.amountOwed, 120);
+});


### PR DESCRIPTION
## Summary
- aggregate member balances based on outstanding charges in `/api/admin/members`
- verify aggregated balances in backend tests

## Testing
- `npm test` in `backend/`
- `npm test` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_687330b869f48328a01ef7b85bbd8cb7