### PR TITLE
Remove separate charges page

### DIFF
--- a/AdminDash.md
+++ b/AdminDash.md
@@ -5,17 +5,16 @@ This document outlines the redesign of the admin dashboard by splitting key func
 ## Quick Links Section
 
 - **Members** – "Browse and manage all member accounts"
-- **Charges** – "View and update all assigned charges"
 
 
-Each quick link will be presented as a button with a short 5–8 word description so admins can immediately navigate to the appropriate tool. The Members and Charges links open their own pages. Payment Reviews remain on the dashboard with a reserved section for future enhancements.
+Each quick link will be presented as a button with a short 5–8 word description so admins can immediately navigate to the appropriate tool. The Members link opens its own page. Payment Reviews remain on the dashboard with a reserved section for future enhancements.
 
 ## Dashboard Layout
 
 1. **Header**
    - Displays the page title and any temporary navigation controls required during development.
 2. **Quick Links**
-   - Horizontally arranged buttons for Members, Charges and Payment Reviews.
+   - Horizontally arranged buttons for Members and Payment Reviews.
    - Each button includes a concise description underneath.
 3. **Payment Reviews Section**
    - Displays a table of pending review requests.
@@ -26,10 +25,10 @@ Each quick link will be presented as a button with a short 5–8 word descriptio
 ## Navigation Strategy
 
 - The header contains temporary buttons to reach new pages during development per `AGENTS.md` guidelines.
-- Members and Charges buttons direct to the new `MembersList` and `ChargeList` pages respectively.
+- The Members button directs to the new `MembersList` page.
 - The Payment Reviews area stays on the main dashboard due to its priority status.
 
 ## Component Reuse
 
-- Shared components such as search bars or sort/filter menus should be abstracted so they can be reused on both the Members and Charges pages.
+- Shared components such as search bars or sort/filter menus should be abstracted so they can be reused across admin pages.
 

--- a/ChargeList.md
+++ b/ChargeList.md
@@ -51,7 +51,7 @@ Mark as Paid
 Marks the charge paid.
 Interaction Flow
 
-Admin clicks Charges in Quick Links on the Dashboard.
+Admin navigates to the Manage Charges page.
 All charges load in the table by default.
 Admin may:
 Type to search

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -6,8 +6,7 @@ import '../styles/AdminDashboard.css';
 
 export default function AdminDashboard({
   onManageCharges,
-  onShowMembers,
-  onShowCharges
+  onShowMembers
 }) {
   const api = useApi();
   const [reviews, setReviews] = useState([]);
@@ -87,10 +86,6 @@ export default function AdminDashboard({
           <span className="desc">
             Add, browse, and manage all member accounts
           </span>
-        </button>
-        <button className="quick-link" onClick={onShowCharges}>
-          Charges
-          <span className="desc">View and update all assigned charges</span>
         </button>
       </section>
       <section>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -5,8 +5,7 @@ import LoginPage from './LoginPage';
 import MemberDashboard from './MemberDashboard';
 import AdminDashboard from './AdminDashboard';
 import MembersList from './MembersList';
-import ChargesList from './ChargesList';
-import ManageCharges from './ManageCharges';
+import ManageChargesPage from './ManageChargesPage';
 import AddMember from './AddMember';
 import PaymentReviewForm from './PaymentReviewForm';
 import ChargeDetails from './ChargeDetails';
@@ -32,7 +31,6 @@ function App() {
   };
   const showAdmin = () => setCurrentPage('admin');
   const showMembersList = () => setCurrentPage('members');
-  const showChargesList = () => setCurrentPage('charges');
   const showManageCharges = () => setCurrentPage('manageCharges');
   const showAddMember = () => setCurrentPage('addMember');
   const showReview = (charge) => {
@@ -87,12 +85,8 @@ function App() {
         <AdminDashboard
           onManageCharges={showManageCharges}
           onShowMembers={showMembersList}
-          onShowCharges={showChargesList}
         />
       );
-      break;
-    case 'manageCharges':
-      pageContent = <ManageCharges onBack={showAdmin} />;
       break;
     case 'members':
       pageContent = (
@@ -102,11 +96,8 @@ function App() {
     case 'addMember':
       pageContent = <AddMember onCancel={showMembersList} />;
       break;
-    case 'charges':
-      pageContent = <ChargesList onBack={showAdmin} />;
-      break;
     case 'manageCharges':
-      pageContent = <ManageCharges onBack={showAdmin} />;
+      pageContent = <ManageChargesPage onBack={showAdmin} />;
       break;
     default:
       pageContent = <LoginPage onLogin={showDashboard} />;

--- a/frontend/src/components/ManageChargesPage.js
+++ b/frontend/src/components/ManageChargesPage.js
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import ChargesList from './ChargesList';
+import ManageCharges from './ManageCharges';
+import '../styles/AdminDashboard.css';
+
+export default function ManageChargesPage({ onBack }) {
+  const [creating, setCreating] = useState(false);
+  if (creating) {
+    return <ManageCharges onBack={() => setCreating(false)} />;
+  }
+  return (
+    <div className="admin-dashboard">
+      <header className="admin-dash-header">
+        <h1>Manage Charges</h1>
+        {onBack && (
+          <button onClick={onBack} className="back-button">Back</button>
+        )}
+      </header>
+      <button onClick={() => setCreating(true)}>Create Charge</button>
+      <ChargesList />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- remove AdminDashboard button for viewing all charges
- drop charges route from `App`
- update design docs for new navigation

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68733063c1a483288bdcdbb887f9dc64