### PR TITLE
Add emphasis to MemberDashboard total balance

### DIFF
--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -44,6 +44,8 @@
 
 .balance-card.total {
   background-color: #e0e0e0;
+  border: 2px solid #282c34;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
 }
 
 .balance-card.overdue {


### PR DESCRIPTION
## Summary
- highlight the Total Balance Due tile so it stands out on the Member Dashboard

## Testing
- `npm run test:coverage` in `frontend`
- `npm run test:coverage` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68733658a68883288a2bc717046c4e0b