### PR TITLE
Expand integration tests for complex payment flows

### DIFF
--- a/backend/test/payment_flow.test.js
+++ b/backend/test/payment_flow.test.js
@@ -1,0 +1,311 @@
+const dbMock = require('./supabaseMock');
+require.cache[require.resolve('../db')] = { exports: dbMock.supabase };
+require.cache[require.resolve('../adminClient')] = { exports: dbMock.supabaseAdmin };
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const app = require('../index');
+
+let server;
+let baseUrl;
+let memberToken;
+let adminToken;
+let memberId;
+
+// start server and log in users
+
+test.before(async () => {
+  await new Promise(resolve => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+
+  let res = await fetch(`${baseUrl}/api/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'member@example.com', password: 'password' })
+  });
+  let data = await res.json();
+  memberToken = data.token;
+  memberId = data.member.id;
+
+  res = await fetch(`${baseUrl}/api/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'admin@example.com', password: 'admin' })
+  });
+  data = await res.json();
+  adminToken = data.token;
+});
+
+test.after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+// ensure clean data before each test
+
+test.beforeEach(() => {
+  dbMock.reset();
+});
+
+async function clearCharges() {
+  const res = await fetch(`${baseUrl}/api/admin/charges`, {
+    headers: { Authorization: `Bearer ${adminToken}` }
+  });
+  const list = await res.json();
+  for (const c of list) {
+    await fetch(`${baseUrl}/api/admin/charges/${c.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${adminToken}` }
+    });
+  }
+}
+
+async function createCharge(amount, dueDate, status = 'Outstanding') {
+  const res = await fetch(`${baseUrl}/api/admin/charges`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${adminToken}`
+    },
+    body: JSON.stringify({ memberId, amount, dueDate, status })
+  });
+  const data = await res.json();
+  return data.id;
+}
+
+async function submitPayment(amount) {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${memberToken}`
+    },
+    body: JSON.stringify({ amount })
+  });
+  const data = await res.json();
+  return data.payment.id;
+}
+
+async function approvePayment(id) {
+  const res = await fetch(`${baseUrl}/api/admin/payments/${id}/approve`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${adminToken}` }
+  });
+  return res.json();
+}
+
+async function denyPayment(id, note = 'No') {
+  const res = await fetch(`${baseUrl}/api/admin/payments/${id}/deny`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${adminToken}`
+    },
+    body: JSON.stringify({ note })
+  });
+  return res.json();
+}
+
+async function listCharges() {
+  const res = await fetch(`${baseUrl}/api/my-charges`, {
+    headers: { Authorization: `Bearer ${memberToken}` }
+  });
+  return res.json();
+}
+
+async function getPayment(id) {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    headers: { Authorization: `Bearer ${memberToken}` }
+  });
+  const list = await res.json();
+  return list.find(p => p.id === id);
+}
+
+// one charge, payment approved
+
+test('single charge approved', async () => {
+  await clearCharges();
+  await createCharge(40, '2025-01-01');
+
+  const pid = await submitPayment(40);
+  let charges = await listCharges();
+  assert.equal(charges.length, 1);
+  assert.equal(charges[0].status, 'Under Review');
+  assert.equal(charges[0].partialAmountPaid, 40);
+
+  await approvePayment(pid);
+  charges = await listCharges();
+  assert.equal(charges[0].status, 'Paid');
+  assert.equal(charges[0].partialAmountPaid, 0);
+
+  const pay = await getPayment(pid);
+  assert.equal(pay.status, 'Approved');
+});
+
+// one charge, payment denied
+
+test('single charge denied', async () => {
+  await clearCharges();
+  await createCharge(50, '2025-01-01');
+
+  const pid = await submitPayment(50);
+  await denyPayment(pid, 'bad');
+  const charges = await listCharges();
+  assert.equal(charges[0].status, 'Outstanding');
+  assert.equal(charges[0].partialAmountPaid, 0);
+  const pay = await getPayment(pid);
+  assert.equal(pay.status, 'Denied');
+});
+
+// two charges one payment approved
+
+test('two charges one payment approved', async () => {
+  await clearCharges();
+  await createCharge(30, '2025-01-01');
+  await createCharge(50, '2025-02-01');
+
+  const pid = await submitPayment(60);
+  let charges = await listCharges();
+  const c1 = charges.find(c => c.amount === 30);
+  const c2 = charges.find(c => c.amount === 50);
+  assert.equal(c1.partialAmountPaid, 30);
+  assert.equal(c2.partialAmountPaid, 30);
+  assert.equal(c1.status, 'Under Review');
+  assert.equal(c2.status, 'Under Review');
+
+  await approvePayment(pid);
+  charges = await listCharges();
+  const a1 = charges.find(c => c.amount === 30);
+  const a2 = charges.find(c => c.amount === 50);
+  assert.equal(a1.status, 'Paid');
+  assert.equal(a1.partialAmountPaid, 0);
+  assert.equal(a2.status, 'Partially Paid');
+  assert.equal(a2.partialAmountPaid, 30);
+});
+
+// two charges two payments approve first deny second
+
+test('two charges two payments mixed', async () => {
+  await clearCharges();
+  await createCharge(30, '2025-01-01');
+  await createCharge(50, '2025-02-01');
+
+  const p1 = await submitPayment(30);
+  const p2 = await submitPayment(50);
+
+  await approvePayment(p1);
+  await denyPayment(p2, 'no');
+
+  const charges = await listCharges();
+  const c1 = charges.find(c => c.amount === 30);
+  const c2 = charges.find(c => c.amount === 50);
+  assert.equal(c1.status, 'Paid');
+  assert.equal(c2.status, 'Outstanding');
+});
+
+// two charges three payments complex ordering
+
+test('two charges three payments complex', async () => {
+  await clearCharges();
+  await createCharge(30, '2025-01-01');
+  await createCharge(50, '2025-02-01');
+
+  const p1 = await submitPayment(30); // charge1
+  const p2 = await submitPayment(20); // charge2 partial
+  await approvePayment(p2);           // charge2 now partially paid 20
+  const p3 = await submitPayment(30); // charge2 now under review 50
+
+  await denyPayment(p1, 'oops');
+  await approvePayment(p3);
+
+  const charges = await listCharges();
+  const c1 = charges.find(c => c.amount === 30);
+  const c2 = charges.find(c => c.amount === 50);
+  assert.equal(c1.status, 'Outstanding');
+  assert.equal(c2.status, 'Paid');
+
+  const pay1 = await getPayment(p1);
+  const pay2 = await getPayment(p2);
+  const pay3 = await getPayment(p3);
+  assert.equal(pay1.status, 'Denied');
+  assert.equal(pay2.status, 'Approved');
+  assert.equal(pay3.status, 'Approved');
+});
+
+// three charges two payments, remainder rolls forward
+
+test('three charges two payments sequential approvals', async () => {
+  await clearCharges();
+  await createCharge(20, '2025-01-01');
+  await createCharge(30, '2025-02-01');
+  await createCharge(40, '2025-03-01');
+
+  const p1 = await submitPayment(60); // fully pays c1/c2, partial c3
+  await approvePayment(p1);
+
+  let charges = await listCharges();
+  let c1 = charges.find(c => c.amount === 20);
+  let c2 = charges.find(c => c.amount === 30);
+  let c3 = charges.find(c => c.amount === 40);
+  assert.equal(c1.status, 'Paid');
+  assert.equal(c2.status, 'Paid');
+  assert.equal(c3.status, 'Partially Paid');
+  assert.equal(c3.partialAmountPaid, 10);
+
+  const p2 = await submitPayment(30); // pay rest of c3
+  await approvePayment(p2);
+  charges = await listCharges();
+  c1 = charges.find(c => c.amount === 20);
+  c2 = charges.find(c => c.amount === 30);
+  c3 = charges.find(c => c.amount === 40);
+  assert.equal(c1.status, 'Paid');
+  assert.equal(c2.status, 'Paid');
+  assert.equal(c3.status, 'Paid');
+  assert.equal(c3.partialAmountPaid, 0);
+});
+
+// three charges multiple payments with mix of approvals and denials
+
+test('three charges four payments complex mix', async () => {
+  await clearCharges();
+  await createCharge(30, '2025-01-01');
+  await createCharge(40, '2025-02-01');
+  await createCharge(50, '2025-03-01');
+
+  const p1 = await submitPayment(20); // toward charge1
+  const p2 = await submitPayment(70); // charge2 + part of charge3
+  await approvePayment(p2);           // approve second payment first
+  await denyPayment(p1, 'bad');       // deny first payment
+
+  let charges = await listCharges();
+  let c1 = charges.find(c => c.amount === 30);
+  let c2 = charges.find(c => c.amount === 40);
+  let c3 = charges.find(c => c.amount === 50);
+  assert.equal(c1.status, 'Outstanding');
+  assert.equal(c2.status, 'Paid');
+  assert.equal(c3.status, 'Partially Paid');
+  assert.equal(c3.partialAmountPaid, 30);
+
+  const p3 = await submitPayment(45); // c1 + partial c3
+  await approvePayment(p3);
+
+  charges = await listCharges();
+  c1 = charges.find(c => c.amount === 30);
+  c2 = charges.find(c => c.amount === 40);
+  c3 = charges.find(c => c.amount === 50);
+  assert.equal(c1.status, 'Paid');
+  assert.equal(c2.status, 'Paid');
+  assert.equal(c3.status, 'Partially Paid');
+  assert.equal(c3.partialAmountPaid, 45);
+
+  const p4 = await submitPayment(5);  // finish c3
+  await approvePayment(p4);
+
+  charges = await listCharges();
+  c3 = charges.find(c => c.amount === 50);
+  assert.equal(c3.status, 'Paid');
+  assert.equal(c3.partialAmountPaid, 0);
+});

--- a/backend/test/supabaseMock.js
+++ b/backend/test/supabaseMock.js
@@ -11,7 +11,7 @@ function loadCsv(file) {
   return parse(csv, { columns: true, skip_empty_lines: true });
 }
 
-const profiles = loadCsv('profiles.csv').map((row) => ({
+let profiles = loadCsv('profiles.csv').map((row) => ({
   id: row.id,
   email: row.email,
   password: row.email === 'admin@example.com' ? 'admin' : 'password',
@@ -23,7 +23,7 @@ const profiles = loadCsv('profiles.csv').map((row) => ({
   tags: row.tags ? row.tags.replace(/[{}]/g, '').split(',').map((t) => t.trim()).filter(Boolean) : []
 }));
 
-const charges = loadCsv('charges.csv').map((row) => ({
+let charges = loadCsv('charges.csv').map((row) => ({
   id: Number(row.id),
   member_id: row.member_id,
   status: row.status,
@@ -176,6 +176,7 @@ const supabase = {
 };
 
 const supabaseAdmin = {
+  from,
   auth: {
     async getUser(token) {
       try {
@@ -210,4 +211,56 @@ const supabaseAdmin = {
   }
 };
 
-module.exports = { supabase, supabaseAdmin };
+function reset() {
+  profiles = loadCsv('profiles.csv').map((row) => ({
+    id: row.id,
+    email: row.email,
+    password: row.email === 'admin@example.com' ? 'admin' : 'password',
+    name: row.name,
+    is_admin: row.is_admin === 'true' || row.is_admin === true,
+    status: row.status,
+    initiation_date: row.initiation_date,
+    amount_owed: Number(row.amount_owed),
+    tags: row.tags
+      ? row.tags
+          .replace(/[{}]/g, '')
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean)
+      : []
+  }));
+
+  charges = loadCsv('charges.csv').map((row) => ({
+    id: Number(row.id),
+    member_id: row.member_id,
+    status: row.status,
+    amount: Number(row.amount),
+    due_date: row.due_date,
+    description: row.description,
+    tags: row.tags
+      ? row.tags
+          .replace(/[{}]/g, '')
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean)
+      : [],
+    partial_amount_paid: 0
+  }));
+
+  payments = [
+    {
+      id: 1,
+      member_id: profiles[0].id,
+      amount: 100,
+      date: '2024-04-15',
+      memo: 'Dues',
+      status: 'Approved',
+      admin_id: profiles[1].id,
+      admin_note: ''
+    }
+  ];
+  nextPaymentId = 2;
+  nextChargeId = Math.max(...charges.map((c) => c.id)) + 1;
+}
+
+module.exports = { supabase, supabaseAdmin, reset };

--- a/integrationTests.md
+++ b/integrationTests.md
@@ -1,0 +1,45 @@
+# Integration Test Guide
+
+This document summarizes the integration tests found under `backend/test`.
+Each test spins up the Express server with a mocked Supabase client so the
+entire API can be exercised without a real database.
+
+## adminClient.test.js
+- **exports stub when SERVICE_ROLE_KEY missing** – ensures the `adminClient` module returns a stub client if no service role key is configured.
+- **creates client when SERVICE_ROLE_KEY provided** – verifies a real Supabase client is created when the service role key exists.
+
+## index.test.js
+- **login succeeds with valid credentials** – user can log in with correct email and password.
+- **login fails with invalid credentials** – invalid login attempts return 401.
+- **get member data requires auth** – `/api/member` requires a valid JWT.
+- **payment submission validates fields** – posting a payment without required fields returns 400.
+- **submit payment succeeds** – successfully submits a payment and confirms it appears in the member's list.
+- **admin endpoints enforce permissions and can approve payment** – ensures regular users cannot access admin routes, while admins can approve payments and see results.
+- **admin can approve payment** – basic approval path verifying status updates.
+- **search members by status** – search filter returns expected members.
+- **admin members endpoint returns aggregated balances** – admin query aggregates outstanding balances per member.
+
+## admin_crud.test.js
+- **admin member CRUD works** – full create, update, delete flow for member records.
+- **admin charge CRUD works** – create, update, and delete charges via admin endpoints.
+- **admin can deny a payment request** – denial workflow reverts charge status and stores the admin note.
+
+## routes.test.js
+- **charges route returns data with stubbed supabase** – verifies the charges route works with a simple stubbed client.
+- **members route returns data with stubbed supabase** – same as above for the members route.
+
+## payment_flow.test.js
+- **single charge approved** – approving a single payment fully pays the matching charge.
+- **single charge denied** – denying a single payment leaves the charge outstanding.
+- **two charges one payment approved** – payment larger than the first charge rolls the remainder to the next charge.
+- **two charges two payments mixed** – mix of approved and denied payments affects charge statuses accordingly.
+- **two charges three payments complex** – complex sequence of approvals and denials covering edge scenarios.
+- **three charges two payments sequential approvals** – multi-charge flow exercising leftover allocation.
+- **three charges four payments complex mix** – mixture of approvals and denials across several payments.
+
+Run all tests with:
+
+```bash
+cd backend
+npm test
+```


### PR DESCRIPTION
## Summary
- add sequential approval scenario and a mixed approval/denial scenario to `payment_flow.test.js`
- document new cases in `integrationTests.md`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873f95d326483288747861205daa1d9