### PR TITLE
Add admin/member dashboard toggle

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -6,7 +6,8 @@ import '../styles/AdminDashboard.css';
 
 export default function AdminDashboard({
   onManageCharges,
-  onShowMembers
+  onShowMembers,
+  onShowMemberDashboard
 }) {
   const api = useApi();
   const [reviews, setReviews] = useState([]);
@@ -74,6 +75,11 @@ export default function AdminDashboard({
     <div className="admin-dashboard">
       <header className="admin-dash-header">
         <h1>Admin Dashboard</h1>
+        {onShowMemberDashboard && (
+          <button className="toggle-button" onClick={onShowMemberDashboard}>
+            Member View
+          </button>
+        )}
       </header>
       {error && <div className="error">{error}</div>}
       <section className="quick-links">

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -59,6 +59,7 @@ function App() {
           onRequestReview={showReview}
           onViewDetails={showChargeDetails}
           pendingReviewIds={pendingReviewIds}
+          onShowAdmin={user?.isAdmin ? showAdmin : undefined}
         />
       );
       break;
@@ -85,6 +86,7 @@ function App() {
         <AdminDashboard
           onManageCharges={showManageCharges}
           onShowMembers={showMembersList}
+          onShowMemberDashboard={showDashboard}
         />
       );
       break;

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -10,12 +10,13 @@ export default function MemberDashboard({
   onRequestReview = () => {},
   onViewDetails = () => {},
   pendingReviewIds = [],
+  onShowAdmin,
 }) {
   const [chargeData, setChargeData] = useState([]);
   const [paymentData, setPaymentData] = useState([]);
   const [loading, setLoading] = useState(true);
   const api = useApi();
-  const { token } = useAuth();
+  const { token, user } = useAuth();
 
   useEffect(() => {
     window.api = api;
@@ -80,7 +81,14 @@ export default function MemberDashboard({
 
   return (
     <div className="member-dashboard">
-      <h1>Dashboard</h1>
+      <header className="member-dash-header">
+        <h1>Dashboard</h1>
+        {user?.isAdmin && onShowAdmin && (
+          <button className="toggle-button" onClick={onShowAdmin}>
+            Admin
+          </button>
+        )}
+      </header>
 
       <div className="balance-info" data-testid="balance-info">
         <div className="balance-summary">

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -38,6 +38,10 @@
   margin-bottom: 10px;
 }
 
+.toggle-button {
+  margin-left: auto;
+}
+
 .admin-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -75,3 +75,13 @@
 .dashboard-review-button:hover {
   background-color: #4db8d6;
 }
+
+.member-dash-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.toggle-button {
+  margin-left: auto;
+}


### PR DESCRIPTION
## Summary
- add ability to switch between dashboards
- show toggle only for admins
- wire toggle props in App
- style toggle button

## Testing
- `npm run test:coverage` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687411e517dc83289535c2cce70c60a5