### PR TITLE
Add Member/Admin toggle switch

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import useApi from '../apiClient';
 import ConfirmDialog from './ConfirmDialog';
 import DataTable from './DataTable';
+import ViewToggle from './ViewToggle';
 import '../styles/AdminDashboard.css';
 
 export default function AdminDashboard({
@@ -74,12 +75,10 @@ export default function AdminDashboard({
   return (
     <div className="admin-dashboard">
       <header className="admin-dash-header">
-        <h1>Admin Dashboard</h1>
         {onShowMemberDashboard && (
-          <button className="toggle-button" onClick={onShowMemberDashboard}>
-            Member View
-          </button>
+          <ViewToggle isAdminView={true} onToggle={onShowMemberDashboard} />
         )}
+        <h1>Admin Dashboard</h1>
       </header>
       {error && <div className="error">{error}</div>}
       <section className="quick-links">

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ChargeList from './ChargeList';
 import PaymentList from './PaymentList';
 import '../styles/MemberDashboard.css';
+import ViewToggle from './ViewToggle';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
 import { getBalanceBreakdown } from '../balanceUtils';
@@ -82,12 +83,10 @@ export default function MemberDashboard({
   return (
     <div className="member-dashboard">
       <header className="member-dash-header">
-        <h1>Dashboard</h1>
         {user?.isAdmin && onShowAdmin && (
-          <button className="toggle-button" onClick={onShowAdmin}>
-            Admin
-          </button>
+          <ViewToggle isAdminView={false} onToggle={onShowAdmin} />
         )}
+        <h1>Dashboard</h1>
       </header>
 
       <div className="balance-info" data-testid="balance-info">

--- a/frontend/src/components/ViewToggle.js
+++ b/frontend/src/components/ViewToggle.js
@@ -1,0 +1,26 @@
+import '../styles/ViewToggle.css';
+
+export default function ViewToggle({ isAdminView = false, onToggle }) {
+  return (
+    <div className="view-toggle" role="group">
+      <button
+        type="button"
+        className={!isAdminView ? 'active' : ''}
+        onClick={() => {
+          if (isAdminView && onToggle) onToggle();
+        }}
+      >
+        Member
+      </button>
+      <button
+        type="button"
+        className={isAdminView ? 'active' : ''}
+        onClick={() => {
+          if (!isAdminView && onToggle) onToggle();
+        }}
+      >
+        Admin
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -35,11 +35,10 @@
 }
 
 .admin-dash-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 10px;
-}
-
-.toggle-button {
-  margin-left: auto;
 }
 
 .admin-table {

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -79,9 +79,6 @@
 .member-dash-header {
   display: flex;
   align-items: center;
+  gap: 8px;
   margin-bottom: 10px;
-}
-
-.toggle-button {
-  margin-left: auto;
 }

--- a/frontend/src/styles/ViewToggle.css
+++ b/frontend/src/styles/ViewToggle.css
@@ -1,0 +1,18 @@
+.view-toggle {
+  display: inline-flex;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.view-toggle button {
+  padding: 4px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.view-toggle button.active {
+  background-color: #282c34;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add a reusable `ViewToggle` component with Member/Admin switch styling
- replace dashboard toggle buttons with `ViewToggle`
- update dashboard header styles for left-aligned toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68742006670083288d464039c783ba6f