### PR TITLE
Add account activity view

### DIFF
--- a/frontend/src/components/AccountActivityPage.js
+++ b/frontend/src/components/AccountActivityPage.js
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+import ChargeList from './ChargeList';
+import PaymentList from './PaymentList';
+import useApi from '../apiClient';
+import { useAuth } from '../AuthContext';
+import '../styles/AccountActivityPage.css';
+
+export default function AccountActivityPage({ onBack }) {
+  const api = useApi();
+  const { token } = useAuth();
+  const [charges, setCharges] = useState([]);
+  const [payments, setPayments] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    async function load() {
+      try {
+        const [c, p] = await Promise.all([
+          api.fetchCharges(),
+          api.fetchPayments()
+        ]);
+        if (c) setCharges(c);
+        if (p) setPayments(p);
+      } catch (err) {
+        console.error('API error', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [token, api]);
+
+  const sortedCharges = [...charges].sort(
+    (a, b) => new Date(b.dueDate) - new Date(a.dueDate)
+  );
+  const sortedPayments = [...payments].sort(
+    (a, b) => new Date(b.date) - new Date(a.date)
+  );
+
+  return (
+    <div className="account-activity-page">
+      <header className="member-dash-header">
+        <h1>Account Activity</h1>
+        {onBack && (
+          <button onClick={onBack} className="back-button">
+            Back
+          </button>
+        )}
+      </header>
+      <section>
+        <h2>All Charges</h2>
+        <ChargeList charges={sortedCharges} loading={loading} />
+      </section>
+      <section>
+        <h2>Payment History</h2>
+        <PaymentList payments={sortedPayments} loading={loading} />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -10,6 +10,7 @@ import AddMember from './AddMember';
 import PaymentReviewForm from './PaymentReviewForm';
 import ChargeDetails from './ChargeDetails';
 import AppShell from './AppShell';
+import AccountActivityPage from './AccountActivityPage';
 
 function App() {
   const [currentPage, setCurrentPage] = useState('login');
@@ -33,6 +34,7 @@ function App() {
   const showMembersList = () => setCurrentPage('members');
   const showManageCharges = () => setCurrentPage('manageCharges');
   const showAddMember = () => setCurrentPage('addMember');
+  const showActivity = () => setCurrentPage('activity');
   const showReview = (charge) => {
     if (charge) {
       setReviewCharge(charge);
@@ -60,8 +62,12 @@ function App() {
           onViewDetails={showChargeDetails}
           pendingReviewIds={pendingReviewIds}
           onShowAdmin={user?.isAdmin ? showAdmin : undefined}
+          onShowActivity={showActivity}
         />
       );
+      break;
+    case 'activity':
+      pageContent = <AccountActivityPage onBack={showDashboard} />;
       break;
     case 'review':
       pageContent = (

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -12,6 +12,7 @@ export default function MemberDashboard({
   onViewDetails = () => {},
   pendingReviewIds = [],
   onShowAdmin,
+  onShowActivity,
 }) {
   const [chargeData, setChargeData] = useState([]);
   const [paymentData, setPaymentData] = useState([]);
@@ -87,6 +88,15 @@ export default function MemberDashboard({
           <ViewToggle isAdminView={false} onToggle={onShowAdmin} />
         )}
         <h1>Dashboard</h1>
+        {onShowActivity && (
+          <button
+            type="button"
+            className="activity-button"
+            onClick={onShowActivity}
+          >
+            Account Activity
+          </button>
+        )}
       </header>
 
       <div className="balance-info" data-testid="balance-info">

--- a/frontend/src/styles/AccountActivityPage.css
+++ b/frontend/src/styles/AccountActivityPage.css
@@ -1,0 +1,12 @@
+.account-activity-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+}
+
+.account-activity-page section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -76,6 +76,19 @@
   background-color: #4db8d6;
 }
 
+.activity-button {
+  margin-left: auto;
+  padding: 6px 12px;
+  background-color: #61dafb;
+  color: #282c34;
+  border: none;
+  cursor: pointer;
+}
+
+.activity-button:hover {
+  background-color: #4db8d6;
+}
+
 .member-dash-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add an AccountActivityPage component showing all charges and payments
- expose page in App navigation
- add Account Activity button on MemberDashboard
- style account activity button

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68759725afb48328a719e7980ac5dbaa