### PR TITLE
Add pagination to DataTable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Several React components in `frontend/src/components` provide shared functionali
 - **SortMenu** – A dropdown select for choosing the current sort order. Pass option objects, a value and `onChange`.
 - **FilterMenu** – Checkbox lists for filtering by status and tags. Accepts options and change handlers for each.
 - **SearchBar** – Generic text input used for searching tables.
-- **DataTable** – Basic table renderer configured via column definitions, data rows and an optional actions render function.
+- **DataTable** – Basic table renderer configured via column definitions, data rows and an optional actions render function. It paginates 10 rows per page with navigation buttons.
 - **NotificationContainer / NotificationContext** – Global toast system for temporary messages. Call `addNotification` to display a message; the container renders them stacked in the corner.
 
 These keep common UI logic centralized so pages like `MembersList` and `ChargesList` stay concise.

--- a/MembersList.md
+++ b/MembersList.md
@@ -19,7 +19,7 @@ Columns include:
 5. **Amount Owed**
 6. **Tags** 
 
-The table should support pagination once the list grows, but initial implementation can show all members.
+The list now paginates 10 members per page with buttons to navigate between pages.
 
 ## Sorting
 

--- a/frontend/src/DataTable.test.js
+++ b/frontend/src/DataTable.test.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DataTable from './components/DataTable';
 
 test('renders table with rows and action buttons', () => {
@@ -17,4 +18,15 @@ test('renders table with rows and action buttons', () => {
   expect(screen.getByText('Name')).toBeInTheDocument();
   expect(screen.getByText('Test')).toBeInTheDocument();
   expect(screen.getByText('Delete 1')).toBeInTheDocument();
+});
+
+test('paginates rows 10 at a time', async () => {
+  const columns = [{ header: 'Name', accessor: 'name' }];
+  const data = Array.from({ length: 15 }, (_, i) => ({ id: i, name: `Row ${i}` }));
+  render(<DataTable columns={columns} data={data} />);
+  // should only show first 10 rows initially
+  expect(screen.getByText('Row 0')).toBeInTheDocument();
+  expect(screen.queryByText('Row 10')).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /next/i }));
+  expect(screen.getByText('Row 10')).toBeInTheDocument();
 });

--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -1,11 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import '../styles/AdminDashboard.css';
+
 export default function DataTable({
   columns = [],
   data = [],
   renderActions,
-  loading = false
+  loading = false,
+  rowsPerPage = 10
 }) {
+  const [page, setPage] = useState(0);
+
+  const totalPages = Math.ceil(data.length / rowsPerPage) || 1;
+  const start = page * rowsPerPage;
+  const visibleRows = data.slice(start, start + rowsPerPage);
+
+  function prev() {
+    setPage((p) => Math.max(p - 1, 0));
+  }
+
+  function next() {
+    setPage((p) => Math.min(p + 1, totalPages - 1));
+  }
+
   return (
     <div className="data-table-wrapper">
       {loading && (
@@ -23,7 +39,7 @@ export default function DataTable({
           </tr>
         </thead>
         <tbody>
-          {data.map((row) => (
+          {visibleRows.map((row) => (
             <tr key={row.id || JSON.stringify(row)}>
               {columns.map((c) => (
                 <td key={c.accessor}>{row[c.accessor]}</td>
@@ -33,6 +49,19 @@ export default function DataTable({
           ))}
         </tbody>
       </table>
+      {totalPages > 1 && (
+        <div className="pagination">
+          <button onClick={prev} disabled={page === 0}>
+            Previous
+          </button>
+          <span>
+            Page {page + 1} of {totalPages}
+          </span>
+          <button onClick={next} disabled={page >= totalPages - 1}>
+            Next
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -111,3 +111,17 @@
     transform: rotate(360deg);
   }
 }
+
+/* DataTable pagination */
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.pagination button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- paginate the shared `DataTable` component at 10 rows by default with navigation buttons
- add pagination styles
- test new pagination logic
- update docs

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687597513a0083289b5bd3a2d75c677c