### PR TITLE
Fix README doc tree after doc shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ conclave-app/
 │
 ├── backend/              ← Node + Express
 │    ├── test
+│    ├── integrationTests.md
 │    └── index.js
 │
 ├── frontend/             ← React app
 │    ├── public
-│    └── src
-│         ├── components  ← JS Components
-│         └── styles      ← CSS
+│    ├── src
+│    │   ├── components  ← JS Components
+│    │   └── styles      ← CSS
+│    └── StyleGuide.md
 │
 ├── README.md
 └── AGENTS.md             ← Instructions for Codex AI


### PR DESCRIPTION
## Summary
- update README project tree after moving docs around

## Testing
- `npm run test:coverage` in `frontend`
- `npm run test:coverage` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68759f2c99308328b31f9e96c6842fdd