### PR TITLE
Handle duplicate email on admin member creation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -362,6 +362,10 @@ app.post('/api/admin/members', auth, adminOnly, async (req, res) => {
   );
   if (rpcErr) {
     console.error('RPC create_user_with_profile failed:', rpcErr);
+    const msg = rpcErr.message || '';
+    if (msg.includes('duplicate key value') && msg.includes('users_email_partial_key')) {
+      return res.status(409).send('Email already exists');
+    }
     return res.status(500).json({ error: rpcErr.message });
   }
 


### PR DESCRIPTION
## Summary
- return a friendlier message when creating a member with a duplicate email

## Testing
- `npm test` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6875a60757d083289c70afc6ab2e7e31