### PR TITLE
Enhance login styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,22 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --color-bg: #F2F8FC;
+  --color-text: #282C34;
+  --color-accent: #5e90db;
+  --color-accent-hover: #3d5f91;
+  --color-surface: #F5F5F5;
+  --color-surface-dark: #E0E0E0;
+  --color-error: #B30000;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -2,7 +2,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  min-height: 100vh;
   padding: 40px;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .login-form {
@@ -10,6 +14,11 @@
   flex-direction: column;
   gap: 12px;
   width: 300px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-surface-dark);
+  border-radius: 8px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .login-form label {
@@ -21,20 +30,36 @@
 .login-form input {
   padding: 8px;
   font-size: 1rem;
+  border: 1px solid var(--color-surface-dark);
+  border-radius: 4px;
 }
 
 .error {
-  color: red;
+  color: var(--color-error);
 }
 
 button {
   padding: 8px;
   font-size: 1rem;
+  background-color: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 180ms ease-in-out, transform 100ms ease-in-out;
 }
 
 button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+button:not(:disabled):hover {
+  background-color: var(--color-accent-hover);
+}
+
+button:not(:disabled):active {
+  transform: scale(0.97);
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- define global color variables and Inter font in `index.css`
- restyle the login page to use style guide colors and interactions

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6875aa5c20ac8328adb0a543bfbee29a