### PR TITLE
Improve login page style

### DIFF
--- a/frontend/StyleGuide.md
+++ b/frontend/StyleGuide.md
@@ -15,7 +15,7 @@ Welcome to the Frontend Style Guide Docs. This guide captures the essential desi
 
 - **Primary (body) font:** *Inter*\
   Designed for legibility on screens, modern yet professional.
-- **Secondary (headings) font:** TBD
+- **Secondary (headings) font:** Roboto Slab
 
 **Base sizes & scale:**
 
@@ -75,7 +75,7 @@ Gutter (gap): `var(--space-lg)` (24px)
 
 **Section Margins:**
 
-- TBD
+- Use vertical spacing of var(--space-lg) (24px) between sections
 
 ## 5. Core UI Components
 

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -3,6 +3,7 @@ import '../styles/LoginPage.css';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
 import { supabase, authFetch } from '../supabaseClient';
+import logo from '../logo.svg';
 
 export default function LoginPage({ onLogin = () => {} }) {
   const [email, setEmail] = useState('');
@@ -39,35 +40,45 @@ export default function LoginPage({ onLogin = () => {} }) {
 
   return (
     <div className="login-page">
-      <h1>Login</h1>
-      <form onSubmit={handleSubmit} className="login-form">
-        <label>
-          Email
+      <div className="login-card">
+        <img src={logo} alt="Conclave logo" className="login-logo" />
+        <h1 className="login-heading">Login</h1>
+        <form onSubmit={handleSubmit} className="login-form">
+          <label htmlFor="email" className="visually-hidden">
+            Email
+          </label>
           <input
+            id="email"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
+            placeholder="Email"
           />
-        </label>
-        <label>
-          Password
+          <label htmlFor="password" className="visually-hidden">
+            Password
+          </label>
           <input
+            id="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            placeholder="Password"
           />
-        </label>
-        {error && <div className="error">{error}</div>}
-        <button type="submit" disabled={loading}>
-          {loading ? (
-            <span className="spinner" aria-label="loading" />
-          ) : (
-            'Login'
-          )}
-        </button>
-      </form>
+          {error && <div className="error">{error}</div>}
+          <button type="submit" disabled={loading}>
+            {loading ? (
+              <span className="spinner" aria-label="loading" />
+            ) : (
+              'Login'
+            )}
+          </button>
+        </form>
+        <a href="#" className="forgot-link">
+          Forgot Password?
+        </a>
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,6 +10,11 @@
   --color-surface-emphasis: #E0E0E0;
   --color-success: #4CAF50;
   --color-error: #B30000;
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
 }
 
 body {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,6 @@
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=Roboto+Slab:wght@400;700&display=swap');
+
 :root {
   --color-background: #F2F8FC;
   --color-text: #282C34;
@@ -14,11 +16,13 @@ body {
   margin: 0;
   background-color: var(--color-background);
   color: var(--color-text);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Roboto Slab', serif;
 }
 
 code {

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -3,6 +3,7 @@
   justify-content: center;
   align-items: center;
   padding: 40px;
+  min-height: 100vh;
 }
 
 .login-card {
@@ -42,6 +43,16 @@
 .login-form input {
   padding: 8px;
   font-size: 1rem;
+  border: 1px solid var(--color-surface-emphasis);
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.login-form input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(94, 144, 219, 0.4);
 }
 
 .error {

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -2,8 +2,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 100vh;
   padding: 40px;
-  min-height: 100vh;
+  box-sizing: border-box;
 }
 
 .login-card {

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -1,9 +1,9 @@
 .login-page {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  height: 100vh;
-  padding: 40px;
+  min-height: 100vh;
+  padding: var(--space-xl) var(--space-xl) 0;
   box-sizing: border-box;
 }
 

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -1,20 +1,41 @@
 .login-page {
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: center;
   padding: 40px;
+}
+
+.login-card {
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 24px;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.login-logo {
+  width: 80px;
+  height: auto;
+}
+
+.login-heading {
+  margin: 0;
+  font-size: 1.5rem;
 }
 
 .login-form {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  width: 300px;
+  width: 100%;
 }
 
 .login-form label {
-  display: flex;
-  flex-direction: column;
+  display: block;
   font-weight: bold;
 }
 
@@ -35,6 +56,27 @@ button {
 button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.forgot-link {
+  font-size: 0.9rem;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.forgot-link:hover {
+  text-decoration: underline;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- update StyleGuide with heading font and section margin values
- load Inter and Roboto Slab fonts globally
- redesign LoginPage with a card and placeholders
- restyle login page to match the design

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6875adf6d3548328b1f8d3cdee5c496c