### PR TITLE
Update member dashboard layout

### DIFF
--- a/frontend/StyleGuide.md
+++ b/frontend/StyleGuide.md
@@ -144,3 +144,11 @@ Gutter (gap): `var(--space-lg)` (24px)
 - **Context API:** `useNotifications()` returns `{ notifications, addNotification, removeNotification }` from `NotificationContext`.
 - **Behaviors:**
   - Vertical stack of toasts, auto-dismiss after 5s, pause on hover, manual close button.
+
+## Member Dashboard Layout
+
+- **Row 1:** Header spanning all 12 columns with page title and global actions.
+- **Row 2:** Ten-column container holding four summary cards. The "Mark as Paid" button sits below the cards, right aligned and styled with the brand accent color.
+- **Row 3:** Ten-column region split 6/4. The left side contains the charges and payments tables; the right side is reserved for an activity feed or chart.
+- During development the rows are temporarily tinted different background colors so their boundaries are clear.
+- Empty state tables show an illustration with a short hint instead of plain text (e.g., "Looks like you've got no outstanding charges").

--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import DataTable from './DataTable';
 import '../styles/ChargeList.css';
+import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 
 export default function ChargeList({
   charges = [],
@@ -14,7 +15,12 @@ export default function ChargeList({
   );
 
   if (!loading && visible.length === 0) {
-    return <div className="charge-list-empty">No charges found.</div>;
+    return (
+      <div className="table-empty">
+        <img src={logo} alt="" className="empty-illustration" />
+        <p>Looks like you've got no outstanding charges.</p>
+      </div>
+    );
   }
 
   const columns = [

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -98,7 +98,6 @@ export default function MemberDashboard({
           </button>
         )}
       </header>
-
       <div className="balance-info" data-testid="balance-info">
         <div className="balance-summary">
           <div
@@ -148,20 +147,25 @@ export default function MemberDashboard({
         </button>
       </div>
 
-      <section>
-        <h2>Outstanding Charges</h2>
-        <ChargeList
-          charges={sortedOutstanding}
-          onViewDetails={onViewDetails}
-          pendingReviewIds={pendingReviewIds}
-          loading={loading}
-        />
-      </section>
+      <div className="dashboard-content">
+        <section className="tables-section">
+          <h2>Outstanding Charges</h2>
+          <ChargeList
+            charges={sortedOutstanding}
+            onViewDetails={onViewDetails}
+            pendingReviewIds={pendingReviewIds}
+            loading={loading}
+          />
 
-      <section>
-        <h2>Recent Payments</h2>
-        <PaymentList payments={sortedPayments} loading={loading} />
-      </section>
+          <h2>Recent Payments</h2>
+          <PaymentList payments={sortedPayments} loading={loading} />
+        </section>
+
+        <aside className="activity-section">
+          <h2>Activity</h2>
+          <div className="activity-placeholder">Activity feed coming soon</div>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/PaymentList.js
+++ b/frontend/src/components/PaymentList.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import DataTable from './DataTable';
 import '../styles/PaymentList.css';
+import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 
 export default function PaymentList({ payments = [], loading = false }) {
   if (!loading && payments.length === 0) {
-    return <div className="payment-list-empty">No payments found.</div>;
+    return (
+      <div className="table-empty">
+        <img src={logo} alt="" className="empty-illustration" />
+        <p>No payments recorded yet.</p>
+      </div>
+    );
   }
 
   const columns = [

--- a/frontend/src/styles/ChargeList.css
+++ b/frontend/src/styles/ChargeList.css
@@ -10,6 +10,13 @@
   text-align: left;
 }
 
-.charge-list-empty {
+.table-empty {
+  text-align: center;
+  padding: var(--space-md);
   font-style: italic;
+}
+
+.table-empty img.empty-illustration {
+  width: 80px;
+  margin-bottom: var(--space-sm);
 }

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -1,29 +1,35 @@
 .member-dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--space-lg);
   padding: 20px;
 }
 
-.member-dashboard section {
+.member-dash-header {
+  grid-column: 1 / -1;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  gap: var(--space-sm);
+  align-items: center;
+  background: rgba(255, 0, 0, 0.1);
+  padding: var(--space-sm);
 }
 
 .balance-info {
+  grid-column: 2 / span 10;
   background-color: var(--color-background);
   padding: 16px;
   border-radius: 4px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   text-align: center;
   gap: 8px;
+  background: rgba(0, 255, 0, 0.1);
 }
 
 .balance-summary {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 8px;
 }
 
@@ -70,6 +76,7 @@
   color: var(--color-text);
   border: none;
   cursor: pointer;
+  align-self: flex-end;
 }
 
 .dashboard-review-button:hover {
@@ -89,10 +96,36 @@
   background-color: var(--color-accent-hover);
 }
 
-.member-dash-header {
+.dashboard-content {
+  grid-column: 2 / span 10;
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: var(--space-lg);
+  background: rgba(0, 0, 255, 0.05);
+}
+
+.tables-section {
+  grid-column: span 6;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 10px;
+  gap: 12px;
+  background: rgba(0, 0, 255, 0.1);
+  padding: var(--space-sm);
+}
+
+.activity-section {
+  grid-column: span 4;
+  background: rgba(255, 255, 0, 0.1);
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.activity-placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-style: italic;
 }

--- a/frontend/src/styles/PaymentList.css
+++ b/frontend/src/styles/PaymentList.css
@@ -10,6 +10,13 @@
   text-align: left;
 }
 
-.payment-list-empty {
+.table-empty {
+  text-align: center;
+  padding: var(--space-md);
   font-style: italic;
+}
+
+.table-empty img.empty-illustration {
+  width: 80px;
+  margin-bottom: var(--space-sm);
 }


### PR DESCRIPTION
## Summary
- redesign MemberDashboard with CSS grid layout
- add placeholders for activity feed
- show icon-based empty states in tables
- align review button and tint layout rows
- document dashboard layout in style guide

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687690bcad508328814d22e4a538d9d5