### PR TITLE
Create button components for consistent styles

### DIFF
--- a/frontend/StyleGuide.md
+++ b/frontend/StyleGuide.md
@@ -105,6 +105,11 @@ Gutter (gap): `var(--space-lg)` (24px)
   - Controlled by the `open` prop
   - Optional input value managed externally
 
+### Buttons
+
+- **PrimaryButton** – Light blue action button used for main actions. Rounded corners.
+- **SecondaryButton** – Gray button for less prominent actions like “Back”.
+
 ### SearchBar
 
 - **Purpose:** Styled input for entering search queries.

--- a/frontend/src/components/AccountActivityPage.js
+++ b/frontend/src/components/AccountActivityPage.js
@@ -4,6 +4,7 @@ import PaymentList from './PaymentList';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
 import '../styles/AccountActivityPage.css';
+import SecondaryButton from './SecondaryButton';
 
 export default function AccountActivityPage({ onBack }) {
   const api = useApi();
@@ -46,9 +47,9 @@ export default function AccountActivityPage({ onBack }) {
       <header className="member-dash-header">
         <h1>Account Activity</h1>
         {onBack && (
-          <button onClick={onBack} className="back-button">
+          <SecondaryButton onClick={onBack} className="back-button">
             Back
-          </button>
+          </SecondaryButton>
         )}
       </header>
       <section>

--- a/frontend/src/components/AddMember.js
+++ b/frontend/src/components/AddMember.js
@@ -3,6 +3,8 @@ import useApi from '../apiClient';
 import ConfirmDialog from './ConfirmDialog';
 import { useNotifications } from '../NotificationContext';
 import '../styles/AddMember.css';
+import PrimaryButton from './PrimaryButton';
+import SecondaryButton from './SecondaryButton';
 
 export default function AddMember({ onCancel }) {
   const api = useApi();
@@ -98,11 +100,11 @@ export default function AddMember({ onCancel }) {
         </label>
         {error && <div className="error">{error}</div>}
         <div className="form-actions">
-          <button type="submit">Submit</button>
+          <PrimaryButton type="submit">Submit</PrimaryButton>
           {onCancel && (
-            <button type="button" onClick={onCancel} className="back-button">
+            <SecondaryButton type="button" onClick={onCancel} className="back-button">
               Cancel
-            </button>
+            </SecondaryButton>
           )}
         </div>
       </form>

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -4,6 +4,8 @@ import ConfirmDialog from './ConfirmDialog';
 import DataTable from './DataTable';
 import ViewToggle from './ViewToggle';
 import '../styles/AdminDashboard.css';
+import PrimaryButton from './PrimaryButton';
+import SecondaryButton from './SecondaryButton';
 
 export default function AdminDashboard({
   onManageCharges,
@@ -82,16 +84,16 @@ export default function AdminDashboard({
       </header>
       {error && <div className="error">{error}</div>}
       <section className="quick-links">
-        <button className="quick-link" onClick={onManageCharges}>
+        <PrimaryButton className="quick-link" onClick={onManageCharges}>
           Manage Charges
           <span className="desc">Create, update, or delete charges for members</span>
-        </button>
-        <button className="quick-link" onClick={onShowMembers}>
+        </PrimaryButton>
+        <PrimaryButton className="quick-link" onClick={onShowMembers}>
           Manage Members
           <span className="desc">
             Add, browse, and manage all member accounts
           </span>
-        </button>
+        </PrimaryButton>
       </section>
       <section>
         <h2>Payment Reviews</h2>
@@ -113,8 +115,12 @@ export default function AdminDashboard({
           }))}
           renderActions={(row) => (
             <div className="flex space-x-2">
-              <button onClick={() => openApproveDialog(row.original)}>Approve</button>
-              <button onClick={() => openDenyDialog(row.original)}>Reject</button>
+              <PrimaryButton onClick={() => openApproveDialog(row.original)}>
+                Approve
+              </PrimaryButton>
+              <SecondaryButton onClick={() => openDenyDialog(row.original)}>
+                Reject
+              </SecondaryButton>
             </div>
           )}
         />

--- a/frontend/src/components/ChargeDetails.js
+++ b/frontend/src/components/ChargeDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import '../styles/ChargeDetails.css';
+import SecondaryButton from './SecondaryButton';
 
 const sampleCharge = {
   id: 1,
@@ -39,9 +40,9 @@ export default function ChargeDetails({ charge, onRequestReview, onBack }) {
 
       <div className="charge-actions">
         {onBack && (
-          <button type="button" onClick={onBack} className="back-button">
+          <SecondaryButton type="button" onClick={onBack} className="back-button">
             Back
-          </button>
+          </SecondaryButton>
         )}
       </div>
     </div>

--- a/frontend/src/components/ChargeItem.js
+++ b/frontend/src/components/ChargeItem.js
@@ -1,3 +1,5 @@
+import SecondaryButton from './SecondaryButton';
+
 export default function ChargeItem({
   id,
   status,
@@ -19,13 +21,13 @@ export default function ChargeItem({
       <td>{displayStatus}</td>
       <td>{partialAmountPaid > 0 ? partialAmountPaid : ''}</td>
       <td className="flex space-x-2">
-        <button
+        <SecondaryButton
           type="button"
           onClick={() => onViewDetails({ id, status, amount, dueDate })}
-          className="px-3 py-1 bg-gray-200 text-gray-800 rounded"
+          className="px-3 py-1"
         >
           Details
-        </button>
+        </SecondaryButton>
       </td>
     </tr>
   );

--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import DataTable from './DataTable';
 import '../styles/ChargeList.css';
+import PrimaryButton from './PrimaryButton';
+import SecondaryButton from './SecondaryButton';
 
 export default function ChargeList({
   charges = [],
@@ -47,7 +49,7 @@ export default function ChargeList({
       data={rows}
       renderActions={(row) => (
         <div className="flex space-x-2">
-          <button
+          <SecondaryButton
             type="button"
             onClick={() =>
               onViewDetails({
@@ -57,10 +59,10 @@ export default function ChargeList({
                 dueDate: row.original.dueDate
               })
             }
-            className="px-3 py-1 bg-gray-200 text-gray-800 rounded"
+            className="px-3 py-1"
           >
             Details
-          </button>
+          </SecondaryButton>
         </div>
       )}
     />

--- a/frontend/src/components/ChargesList.js
+++ b/frontend/src/components/ChargesList.js
@@ -5,6 +5,8 @@ import SortMenu from './SortMenu';
 import FilterMenu from './FilterMenu';
 import DataTable from './DataTable';
 import '../styles/AdminDashboard.css';
+import SecondaryButton from './SecondaryButton';
+import PrimaryButton from './PrimaryButton';
 
 const STATUS_OPTIONS = ['Outstanding', 'Paid', 'Delinquent', 'Under Review'];
 
@@ -65,7 +67,9 @@ export default function ChargesList({ onBack }) {
       <header className="admin-dash-header">
         <h1>Charge List</h1>
         {onBack && (
-          <button onClick={onBack} className="back-button">Back</button>
+          <SecondaryButton onClick={onBack} className="back-button">
+            Back
+          </SecondaryButton>
         )}
       </header>
       {error && <div className="error">{error}</div>}
@@ -98,10 +102,14 @@ export default function ChargesList({ onBack }) {
         })}
         renderActions={(row) => (
           <div className="action-buttons">
-            {row.status !== 'Paid' && (
-              <button onClick={() => handleMarkPaid(row.id)}>Mark Paid</button>
-            )}
-            <button onClick={() => handleDelete(row.id)}>Delete</button>
+              {row.status !== 'Paid' && (
+                <PrimaryButton onClick={() => handleMarkPaid(row.id)}>
+                  Mark Paid
+                </PrimaryButton>
+              )}
+              <SecondaryButton onClick={() => handleDelete(row.id)}>
+                Delete
+              </SecondaryButton>
           </div>
         )}
       />

--- a/frontend/src/components/ConfirmDialog.js
+++ b/frontend/src/components/ConfirmDialog.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import '../styles/ConfirmDialog.css';
+import PrimaryButton from './PrimaryButton';
+import SecondaryButton from './SecondaryButton';
 
 export default function ConfirmDialog({
   open = false,
@@ -51,12 +53,12 @@ export default function ConfirmDialog({
           {errorText && <div className="error">{errorText}</div>}
         </div>
         <div className="confirm-dialog-actions">
-          <button type="button" onClick={handleConfirm} className="confirm-button">
+          <PrimaryButton type="button" onClick={handleConfirm} className="confirm-button">
             {confirmText}
-          </button>
-          <button type="button" onClick={onCancel} className="cancel-button">
+          </PrimaryButton>
+          <SecondaryButton type="button" onClick={onCancel} className="cancel-button">
             {cancelText}
-          </button>
+          </SecondaryButton>
         </div>
       </div>
     </div>

--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import '../styles/AdminDashboard.css';
+import SecondaryButton from './SecondaryButton';
 
 export default function DataTable({
   columns = [],
@@ -51,15 +52,15 @@ export default function DataTable({
       </table>
       {totalPages > 1 && (
         <div className="pagination">
-          <button onClick={prev} disabled={page === 0}>
+          <SecondaryButton onClick={prev} disabled={page === 0}>
             Previous
-          </button>
+          </SecondaryButton>
           <span>
             Page {page + 1} of {totalPages}
           </span>
-          <button onClick={next} disabled={page >= totalPages - 1}>
+          <SecondaryButton onClick={next} disabled={page >= totalPages - 1}>
             Next
-          </button>
+          </SecondaryButton>
         </div>
       )}
     </div>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,4 +1,5 @@
 import '../styles/Header.css';
+import PrimaryButton from './PrimaryButton';
 
 export default function Header({
   onShowDashboard,
@@ -14,54 +15,54 @@ export default function Header({
         <span className="brand">Conclave ΣΧ-ΛΔ</span>
         <div className="nav-actions">
           {onShowLogin && (
-            <button
+            <PrimaryButton
               type="button"
               className="nav-button login-nav-button"
               onClick={onShowLogin}
             >
               Login
-            </button>
+            </PrimaryButton>
           )}
           {onShowDashboard && (
-            <button
+            <PrimaryButton
               type="button"
               className="nav-button dashboard-nav-button"
               onClick={onShowDashboard}
             >
               Dashboard
-            </button>
+            </PrimaryButton>
           )}
           {onShowAdmin && (
-            <button
+            <PrimaryButton
               type="button"
               className="nav-button admin-nav-button"
               onClick={onShowAdmin}
             >
               Admin
-            </button>
+            </PrimaryButton>
           )}
           {onShowReview && (
-            <button
+            <PrimaryButton
               type="button"
               className="nav-button review-nav-button"
               onClick={onShowReview}
             >
               Payment Review
-            </button>
+            </PrimaryButton>
           )}
           {onShowChargeDetails && (
-            <button
+            <PrimaryButton
               type="button"
               className="nav-button charge-details-nav-button"
               onClick={onShowChargeDetails}
             >
               Charge Details
-            </button>
+            </PrimaryButton>
           )}
           {onLogout && (
-            <button type="button" className="nav-button logout-button" onClick={onLogout}>
+            <PrimaryButton type="button" className="nav-button logout-button" onClick={onLogout}>
               Logout
-            </button>
+            </PrimaryButton>
           )}
         </div>
       </nav>

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -3,6 +3,7 @@ import '../styles/LoginPage.css';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
 import { supabase, authFetch } from '../supabaseClient';
+import PrimaryButton from './PrimaryButton';
 import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 
 export default function LoginPage({ onLogin = () => {} }) {
@@ -66,13 +67,13 @@ export default function LoginPage({ onLogin = () => {} }) {
             placeholder="Password"
           />
           {error && <div className="error">{error}</div>}
-          <button type="submit" disabled={loading}>
+          <PrimaryButton type="submit" disabled={loading}>
             {loading ? (
               <span className="spinner" aria-label="loading" />
             ) : (
               'Login'
             )}
-          </button>
+          </PrimaryButton>
         </form>
         <a href="#" className="forgot-link">
           Forgot Password?

--- a/frontend/src/components/ManageCharges.js
+++ b/frontend/src/components/ManageCharges.js
@@ -5,6 +5,8 @@ import FilterMenu from './FilterMenu';
 import ConfirmDialog from './ConfirmDialog';
 import { useNotifications } from '../NotificationContext';
 import '../styles/ManageCharges.css';
+import PrimaryButton from './PrimaryButton';
+import SecondaryButton from './SecondaryButton';
 
 const STATUS_OPTIONS = ['Active', 'Alumni', 'Inactive', 'Suspended', 'Expelled'];
 
@@ -157,9 +159,9 @@ export default function ManageCharges({ onBack }) {
               onChangeStatuses={setStatusFilter}
               onChangeTags={() => {}}
             />
-            <button type="button" onClick={selectAllMatching} disabled={filteredMembers.length === 0}>
+            <PrimaryButton type="button" onClick={selectAllMatching} disabled={filteredMembers.length === 0}>
               Select All Matching
-            </button>
+            </PrimaryButton>
             <div className="selected-count">
               {selectedIds.length} of {members.length} members selected
             </div>
@@ -254,16 +256,17 @@ export default function ManageCharges({ onBack }) {
         </div>
       )}
       <div className="wizard-footer">
-        <button type="button" onClick={handleBack}>Back</button>
+        <SecondaryButton type="button" onClick={handleBack}
+          >Back</SecondaryButton>
         {step < 3 && (
-          <button type="button" onClick={handleNext} disabled={nextDisabled()}>
+          <PrimaryButton type="button" onClick={handleNext} disabled={nextDisabled()}>
             Next
-          </button>
+          </PrimaryButton>
         )}
         {step === 3 && (
-          <button type="button" onClick={() => setShowConfirm(true)}>
+          <PrimaryButton type="button" onClick={() => setShowConfirm(true)}>
             Create Charge
-          </button>
+          </PrimaryButton>
         )}
       </div>
       <ConfirmDialog

--- a/frontend/src/components/ManageChargesPage.js
+++ b/frontend/src/components/ManageChargesPage.js
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import ChargesList from './ChargesList';
 import ManageCharges from './ManageCharges';
 import '../styles/AdminDashboard.css';
+import SecondaryButton from './SecondaryButton';
+import PrimaryButton from './PrimaryButton';
 
 export default function ManageChargesPage({ onBack }) {
   const [creating, setCreating] = useState(false);
@@ -13,10 +15,12 @@ export default function ManageChargesPage({ onBack }) {
       <header className="admin-dash-header">
         <h1>Manage Charges</h1>
         {onBack && (
-          <button onClick={onBack} className="back-button">Back</button>
+          <SecondaryButton onClick={onBack} className="back-button">
+            Back
+          </SecondaryButton>
         )}
       </header>
-      <button onClick={() => setCreating(true)}>Create Charge</button>
+      <PrimaryButton onClick={() => setCreating(true)}>Create Charge</PrimaryButton>
       <ChargesList />
     </div>
   );

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -3,6 +3,7 @@ import ChargeList from './ChargeList';
 import PaymentList from './PaymentList';
 import '../styles/MemberDashboard.css';
 import ViewToggle from './ViewToggle';
+import PrimaryButton from './PrimaryButton';
 import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
 import { getBalanceBreakdown } from '../balanceUtils';
@@ -89,13 +90,13 @@ export default function MemberDashboard({
         )}
         <h1>Dashboard</h1>
         {onShowActivity && (
-          <button
+          <PrimaryButton
             type="button"
             className="activity-button"
             onClick={onShowActivity}
           >
             Account Activity
-          </button>
+          </PrimaryButton>
         )}
       </header>
 
@@ -137,7 +138,7 @@ export default function MemberDashboard({
             <div className="breakdown-error">Unable to calculate breakdown.</div>
           )}
         </div>
-        <button
+        <PrimaryButton
           type="button"
           className="dashboard-review-button"
           data-testid="dashboard-review-button"
@@ -145,7 +146,7 @@ export default function MemberDashboard({
           onClick={() => onRequestReview({ amount: totalBalance })}
         >
           Mark as Paid
-        </button>
+        </PrimaryButton>
       </div>
 
       <section>

--- a/frontend/src/components/MembersList.js
+++ b/frontend/src/components/MembersList.js
@@ -6,6 +6,8 @@ import SortMenu from './SortMenu';
 import FilterMenu from './FilterMenu';
 import DataTable from './DataTable';
 import '../styles/AdminDashboard.css';
+import SecondaryButton from './SecondaryButton';
+import PrimaryButton from './PrimaryButton';
 
 const STATUS_OPTIONS = ['Active', 'Alumni', 'Inactive', 'Suspended', 'Expelled'];
 
@@ -50,10 +52,14 @@ export default function MembersList({ onBack, onAdd }) {
         <h1>Members List</h1>
         <div className="action-buttons">
           {onBack && (
-            <button onClick={onBack} className="back-button">Back</button>
+            <SecondaryButton onClick={onBack} className="back-button">
+              Back
+            </SecondaryButton>
           )}
           {onAdd && (
-            <button onClick={onAdd} className="add-button">Add Member</button>
+            <PrimaryButton onClick={onAdd} className="add-button">
+              Add Member
+            </PrimaryButton>
           )}
         </div>
       </header>

--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import '../styles/PaymentReviewForm.css';
 import useApi from '../apiClient';
 import { useNotifications } from '../NotificationContext';
+import PrimaryButton from './PrimaryButton';
+import SecondaryButton from './SecondaryButton';
 
 const sampleCharge = { id: 1, amount: '$200', description: 'Charge' };
 
@@ -88,11 +90,11 @@ export default function PaymentReviewForm({
         {error && <div className="error">{error}</div>}
         {message && <div className="success">{message}</div>}
         <div className="form-actions">
-          <button type="submit">Submit</button>
+          <PrimaryButton type="submit">Submit</PrimaryButton>
           {onBack && (
-            <button type="button" onClick={onBack} className="back-button">
+            <SecondaryButton type="button" onClick={onBack} className="back-button">
               Back
-            </button>
+            </SecondaryButton>
           )}
         </div>
       </form>

--- a/frontend/src/components/PrimaryButton.js
+++ b/frontend/src/components/PrimaryButton.js
@@ -1,0 +1,9 @@
+import '../styles/Button.css';
+
+export default function PrimaryButton({ children, className = '', ...props }) {
+  return (
+    <button className={`primary-button ${className}`.trim()} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/SecondaryButton.js
+++ b/frontend/src/components/SecondaryButton.js
@@ -1,0 +1,9 @@
+import '../styles/Button.css';
+
+export default function SecondaryButton({ children, className = '', ...props }) {
+  return (
+    <button className={`secondary-button ${className}`.trim()} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/styles/Button.css
+++ b/frontend/src/styles/Button.css
@@ -1,0 +1,24 @@
+.primary-button {
+  padding: 6px 12px;
+  background-color: var(--color-accent);
+  color: var(--color-text);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primary-button:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.secondary-button {
+  padding: 6px 12px;
+  background-color: #e0e0e0;
+  color: var(--color-text);
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+
+.secondary-button:hover {
+  background-color: #d5d5d5;
+}

--- a/frontend/src/styles/Header.css
+++ b/frontend/src/styles/Header.css
@@ -27,13 +27,5 @@
 }
 
 .nav-button {
-  background-color: var(--color-accent);
-  color: var(--color-text);
-  border: none;
   padding: 5px 10px;
-  cursor: pointer;
-}
-
-.nav-button:hover {
-  background-color: var(--color-accent-hover);
 }

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -66,27 +66,11 @@
 .dashboard-review-button {
   margin-top: 8px;
   padding: 6px 12px;
-  background-color: var(--color-accent);
-  color: var(--color-text);
-  border: none;
-  cursor: pointer;
-}
-
-.dashboard-review-button:hover {
-  background-color: var(--color-accent-hover);
 }
 
 .activity-button {
   margin-left: auto;
   padding: 6px 12px;
-  background-color: var(--color-accent);
-  color: var(--color-text);
-  border: none;
-  cursor: pointer;
-}
-
-.activity-button:hover {
-  background-color: var(--color-accent-hover);
 }
 
 .member-dash-header {


### PR DESCRIPTION
## Summary
- add `PrimaryButton` and `SecondaryButton` components with shared styles
- refactor existing buttons to use the new components
- simplify button-related CSS
- document the new buttons in the style guide

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6876a0bd4a808328ab3851240f7cb39c