### PR TITLE
Move payments table beside outstanding charges

### DIFF
--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -157,14 +157,11 @@ export default function MemberDashboard({
             pendingReviewIds={pendingReviewIds}
             loading={loading}
           />
-
-          <h2>Recent Payments</h2>
-          <PaymentList payments={sortedPayments} loading={loading} />
         </section>
 
-        <aside className="activity-section">
-          <h2>Activity</h2>
-          <div className="activity-placeholder">Activity feed coming soon</div>
+        <aside className="payments-section">
+          <h2>Recent Payments</h2>
+          <PaymentList payments={sortedPayments} loading={loading} />
         </aside>
       </div>
     </div>

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -105,19 +105,11 @@
   padding: var(--space-sm);
 }
 
-.activity-section {
+.payments-section {
   grid-column: span 4;
   background: rgba(255, 255, 0, 0.1);
   padding: var(--space-sm);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
-}
-
-.activity-placeholder {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-style: italic;
 }


### PR DESCRIPTION
## Summary
- remove Activity sidebar and replace with payments table
- keep charges and payments side by side

## Testing
- `npm test --prefix frontend` *(fails: App.test.js syntax error)*
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6876c07fbf8c83289b25733d67a1bc0e