### PR TITLE
Move Mark Paid button column to left

### DIFF
--- a/frontend/src/components/ChargesList.js
+++ b/frontend/src/components/ChargesList.js
@@ -87,6 +87,7 @@ export default function ChargesList({ onBack }) {
       />
       <DataTable
         loading={loading}
+        actionsPosition="left"
         columns={[
           { header: 'Member', accessor: 'memberName' },
           { header: 'Description', accessor: 'description' },

--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -6,6 +6,7 @@ export default function DataTable({
   columns = [],
   data = [],
   renderActions,
+  actionsPosition = 'right',
   loading = false,
   rowsPerPage = 10
 }) {
@@ -33,19 +34,25 @@ export default function DataTable({
       <table className="admin-table">
         <thead>
           <tr>
+            {actionsPosition === 'left' && renderActions && <th>Actions</th>}
             {columns.map((c) => (
               <th key={c.accessor}>{c.header}</th>
             ))}
-            {renderActions && <th>Actions</th>}
+            {actionsPosition === 'right' && renderActions && <th>Actions</th>}
           </tr>
         </thead>
         <tbody>
           {visibleRows.map((row) => (
             <tr key={row.id || JSON.stringify(row)}>
+              {actionsPosition === 'left' && renderActions && (
+                <td>{renderActions(row)}</td>
+              )}
               {columns.map((c) => (
                 <td key={c.accessor}>{row[c.accessor]}</td>
               ))}
-              {renderActions && <td>{renderActions(row)}</td>}
+              {actionsPosition === 'right' && renderActions && (
+                <td>{renderActions(row)}</td>
+              )}
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- add optional `actionsPosition` prop to `DataTable`
- show `Mark Paid` button column on the left in `ChargesList`

## Testing
- `npm test --silent` *(fails: App.test.js unexpected token)*
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6876c09c292483288365ec08fe61d82e