### PR TITLE
Move member/admin toggle

### DIFF
--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -84,11 +84,13 @@ export default function MemberDashboard({
 
   return (
     <div className="member-dashboard">
+      {user?.isAdmin && onShowAdmin && (
+        <div className="view-toggle-wrapper">
+          <ViewToggle isAdminView={false} onToggle={onShowAdmin} />
+        </div>
+      )}
       <header className="member-dash-header">
         <h1>Dashboard</h1>
-        {user?.isAdmin && onShowAdmin && (
-          <ViewToggle isAdminView={false} onToggle={onShowAdmin} />
-        )}
         {onShowActivity && (
           <PrimaryButton
             type="button"

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -14,6 +14,10 @@
   padding: var(--space-sm);
 }
 
+.view-toggle-wrapper {
+  grid-column: 1 / span 2;
+}
+
 
 .balance-info {
   grid-column: 2 / span 10;
@@ -129,6 +133,9 @@
   }
   .member-dash-header h1 {
     flex-basis: 100%;
+  }
+  .view-toggle-wrapper {
+    grid-column: 1 / -1;
   }
   .balance-info,
   .dashboard-content {


### PR DESCRIPTION
## Summary
- put the Member/Admin view toggle into its own grid slot
- add styles for new grid location

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6876e85b78d88328993bd243dbaa3f56