### PR TITLE
Fix mobile layout for dashboard tables

### DIFF
--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -134,4 +134,11 @@
   .dashboard-content {
     grid-column: 1 / -1;
   }
+  .dashboard-content {
+    grid-template-columns: 1fr;
+  }
+  .tables-section,
+  .payments-section {
+    grid-column: 1 / -1;
+  }
 }


### PR DESCRIPTION
## Summary
- tweak MemberDashboard responsive CSS to stack tables vertically in mobile view

## Testing
- `cd frontend && npm run test:coverage`
- `cd backend && npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_6876e9352ed483289947304cd772998f