### PR TITLE
Update dashboard navigation

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -17,23 +17,51 @@ function App() {
   const [reviewCharge, setReviewCharge] = useState(null);
   const [detailsCharge, setDetailsCharge] = useState(null);
   const [pendingReviewIds, setPendingReviewIds] = useState([]);
+  const [isAdminView, setIsAdminView] = useState(false);
   const { token, setToken, setUser, user } = useAuth();
 
-  const showDashboard = () => {
+  const showMemberDashboard = () => {
+    setIsAdminView(false);
     setCurrentPage('dashboard');
     setReviewCharge(null);
     setDetailsCharge(null);
+  };
+  const showAdminDashboard = () => {
+    setIsAdminView(true);
+    setCurrentPage('admin');
+    setReviewCharge(null);
+    setDetailsCharge(null);
+  };
+  const showDashboard = () => {
+    if (isAdminView) {
+      showAdminDashboard();
+    } else {
+      showMemberDashboard();
+    }
   };
   const showLogin = () => setCurrentPage('login');
   const handleLogout = () => {
     setToken(null);
     setUser(null);
+    setIsAdminView(false);
     showLogin();
   };
-  const showAdmin = () => setCurrentPage('admin');
-  const showMembersList = () => setCurrentPage('members');
-  const showManageCharges = () => setCurrentPage('manageCharges');
-  const showAddMember = () => setCurrentPage('addMember');
+  const showAdmin = () => {
+    setIsAdminView(true);
+    setCurrentPage('admin');
+  };
+  const showMembersList = () => {
+    setIsAdminView(true);
+    setCurrentPage('members');
+  };
+  const showManageCharges = () => {
+    setIsAdminView(true);
+    setCurrentPage('manageCharges');
+  };
+  const showAddMember = () => {
+    setIsAdminView(true);
+    setCurrentPage('addMember');
+  };
   const showActivity = () => setCurrentPage('activity');
   const showReview = (charge) => {
     if (charge) {
@@ -62,7 +90,6 @@ function App() {
           onViewDetails={showChargeDetails}
           pendingReviewIds={pendingReviewIds}
           onShowAdmin={user?.isAdmin ? showAdmin : undefined}
-          onShowActivity={showActivity}
         />
       );
       break;
@@ -92,7 +119,7 @@ function App() {
         <AdminDashboard
           onManageCharges={showManageCharges}
           onShowMembers={showMembersList}
-          onShowMemberDashboard={showDashboard}
+          onShowMemberDashboard={showMemberDashboard}
         />
       );
       break;
@@ -112,7 +139,11 @@ function App() {
   }
 
   return (
-    <AppShell onShowLogin={showLogin} onLogout={token ? handleLogout : undefined}>
+    <AppShell
+      onShowDashboard={showDashboard}
+      onShowActivity={showActivity}
+      onLogout={token ? handleLogout : undefined}
+    >
       {pageContent}
     </AppShell>
   );

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -140,8 +140,8 @@ function App() {
 
   return (
     <AppShell
-      onShowDashboard={showDashboard}
-      onShowActivity={showActivity}
+      onShowDashboard={token ? showDashboard : undefined}
+      onShowActivity={token && !isAdminView ? showActivity : undefined}
       onLogout={token ? handleLogout : undefined}
     >
       {pageContent}

--- a/frontend/src/components/AppShell.js
+++ b/frontend/src/components/AppShell.js
@@ -2,10 +2,19 @@ import Header from './Header';
 import NotificationContainer from './NotificationContainer';
 import '../styles/AppShell.css';
 
-export default function AppShell({ children, onShowLogin, onLogout }) {
+export default function AppShell({
+  children,
+  onShowDashboard,
+  onShowActivity,
+  onLogout,
+}) {
   return (
     <div className="app-shell">
-      <Header onShowLogin={onShowLogin} onLogout={onLogout} />
+      <Header
+        onShowDashboard={onShowDashboard}
+        onShowActivity={onShowActivity}
+        onLogout={onLogout}
+      />
       <NotificationContainer />
       <main className="app-content">{children}</main>
     </div>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -7,6 +7,7 @@ export default function Header({
   onShowAdmin,
   onShowReview,
   onShowChargeDetails,
+  onShowActivity,
   onLogout,
 }) {
   return (
@@ -30,6 +31,15 @@ export default function Header({
               onClick={onShowDashboard}
             >
               Dashboard
+            </PrimaryButton>
+          )}
+          {onShowActivity && (
+            <PrimaryButton
+              type="button"
+              className="nav-button activity-nav-button"
+              onClick={onShowActivity}
+            >
+              Account Activity
             </PrimaryButton>
           )}
           {onShowAdmin && (

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -13,7 +13,6 @@ export default function MemberDashboard({
   onViewDetails = () => {},
   pendingReviewIds = [],
   onShowAdmin,
-  onShowActivity,
 }) {
   const [chargeData, setChargeData] = useState([]);
   const [paymentData, setPaymentData] = useState([]);
@@ -91,15 +90,6 @@ export default function MemberDashboard({
       )}
       <header className="member-dash-header">
         <h1>Dashboard</h1>
-        {onShowActivity && (
-          <PrimaryButton
-            type="button"
-            className="activity-button"
-            onClick={onShowActivity}
-          >
-            Account Activity
-          </PrimaryButton>
-        )}
       </header>
       <div className="balance-info" data-testid="balance-info">
         <div className="balance-summary">

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -88,10 +88,6 @@
   background-color: var(--color-accent-hover);
 }
 
-.activity-button {
-  margin-left: auto;
-  padding: 6px 12px;
-}
 
 .dashboard-content {
   grid-column: 2 / span 10;


### PR DESCRIPTION
## Summary
- replace MemberDashboard activity button with new navbar link
- drop login button from the header
- include account activity in the header
- add dashboard button that switches based on admin state
- track member/admin state in `App`

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876ea93eac483289527e30cb780d8cb