### PR TITLE
Revamp dashboard table styles

### DIFF
--- a/frontend/StyleGuide.md
+++ b/frontend/StyleGuide.md
@@ -5,7 +5,7 @@ Welcome to the Frontend Style Guide Docs. This guide captures the essential desi
 ## Color Palette
 
 - **Background:** White `#F2F8FC`
-- **Text / Primary Content:** Dark blue `#282C34`
+- **Text / Primary Content:** Navy `#282C34`
 - **Accent:** Light blue `#a8d0ff` (hover `#82b4e5`)
 - **Surfaces:** Light gray `#F5F5F5` with darker `#E0E0E0` for emphasis
 - **Status Highlights:** Success `#4CAF50`, error `#B30000`

--- a/frontend/src/DataTable.test.js
+++ b/frontend/src/DataTable.test.js
@@ -30,3 +30,13 @@ test('paginates rows 10 at a time', async () => {
   await userEvent.click(screen.getByRole('button', { name: /next/i }));
   expect(screen.getByText('Row 10')).toBeInTheDocument();
 });
+
+test('calls onRowClick when a row is clicked', async () => {
+  const columns = [{ header: 'Name', accessor: 'name' }];
+  const data = [{ id: 1, name: 'Row 1' }];
+  const handle = jest.fn();
+  render(<DataTable columns={columns} data={data} onRowClick={handle} />);
+  const rows = screen.getAllByRole('row');
+  await userEvent.click(rows[1]);
+  expect(handle).toHaveBeenCalledWith(data[0]);
+});

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -9,6 +9,7 @@ import ManageChargesPage from './ManageChargesPage';
 import AddMember from './AddMember';
 import PaymentReviewForm from './PaymentReviewForm';
 import ChargeDetails from './ChargeDetails';
+import PaymentDetails from './PaymentDetails';
 import AppShell from './AppShell';
 import AccountActivityPage from './AccountActivityPage';
 
@@ -16,6 +17,7 @@ function App() {
   const [currentPage, setCurrentPage] = useState('login');
   const [reviewCharge, setReviewCharge] = useState(null);
   const [detailsCharge, setDetailsCharge] = useState(null);
+  const [detailsPayment, setDetailsPayment] = useState(null);
   const [pendingReviewIds, setPendingReviewIds] = useState([]);
   const [isAdminView, setIsAdminView] = useState(false);
   const { token, setToken, setUser, user } = useAuth();
@@ -81,13 +83,21 @@ function App() {
     setCurrentPage('chargeDetails');
   };
 
+  const showPaymentDetails = (payment) => {
+    if (payment) {
+      setDetailsPayment(payment);
+    }
+    setCurrentPage('paymentDetails');
+  };
+
   let pageContent;
   switch (currentPage) {
     case 'dashboard':
       pageContent = (
         <MemberDashboard
           onRequestReview={showReview}
-          onViewDetails={showChargeDetails}
+          onViewChargeDetails={showChargeDetails}
+          onViewPaymentDetails={showPaymentDetails}
           pendingReviewIds={pendingReviewIds}
           onShowAdmin={user?.isAdmin ? showAdmin : undefined}
         />
@@ -110,6 +120,14 @@ function App() {
         <ChargeDetails
           charge={detailsCharge || undefined}
           onRequestReview={showReview}
+          onBack={showDashboard}
+        />
+      );
+      break;
+    case 'paymentDetails':
+      pageContent = (
+        <PaymentDetails
+          payment={detailsPayment || undefined}
           onBack={showDashboard}
         />
       );

--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -27,10 +27,9 @@ export default function ChargeList({
 
   const columns = [
     { header: 'Description', accessor: 'description' },
-    { header: 'Original Amount', accessor: 'amount' },
+    { header: 'Amount', accessor: 'amount' },
     { header: 'Due Date', accessor: 'dueDate' },
-    { header: 'Status', accessor: 'statusDisplay' },
-    { header: 'Partial Amount Paid', accessor: 'partial' }
+    { header: 'Status', accessor: 'statusDisplay' }
   ];
 
   const rows = visible.map((charge) => {
@@ -43,7 +42,6 @@ export default function ChargeList({
       amount: charge.amount,
       dueDate: new Date(charge.dueDate).toLocaleDateString(),
       statusDisplay,
-      partial: charge.partialAmountPaid > 0 ? charge.partialAmountPaid : '',
       original: charge
     };
   });
@@ -52,25 +50,15 @@ export default function ChargeList({
     <DataTable
       loading={loading}
       columns={columns}
-      data={rows}
-      renderActions={(row) => (
-        <div className="flex space-x-2">
-          <SecondaryButton
-            type="button"
-            onClick={() =>
-              onViewDetails({
-                id: row.original.id,
-                status: row.original.status,
-                amount: row.original.amount,
-                dueDate: row.original.dueDate
-              })
-            }
-            className="px-3 py-1"
-          >
-            Details
-          </SecondaryButton>
-        </div>
-      )}
+      data={rows.map((r) => ({ ...r, amount: `$${r.amount}` }))}
+      onRowClick={(row) =>
+        onViewDetails({
+          id: row.original.id,
+          status: row.original.status,
+          amount: row.original.amount,
+          dueDate: row.original.dueDate
+        })
+      }
     />
   );
 }

--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -7,7 +7,8 @@ export default function DataTable({
   data = [],
   renderActions,
   loading = false,
-  rowsPerPage = 10
+  rowsPerPage = 10,
+  onRowClick
 }) {
   const [page, setPage] = useState(0);
 
@@ -41,10 +42,19 @@ export default function DataTable({
         </thead>
         <tbody>
           {visibleRows.map((row) => (
-            <tr key={row.id || JSON.stringify(row)}>
-              {columns.map((c) => (
-                <td key={c.accessor}>{row[c.accessor]}</td>
-              ))}
+            <tr
+              key={row.id || JSON.stringify(row)}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              className={onRowClick ? 'clickable-row' : undefined}
+            >
+              {columns.map((c) => {
+                const value = row[c.accessor];
+                const isMoney =
+                  typeof value === 'number' &&
+                  c.header.toLowerCase().includes('amount');
+                const display = isMoney ? `$${value}` : value;
+                return <td key={c.accessor}>{display}</td>;
+              })}
               {renderActions && <td>{renderActions(row)}</td>}
             </tr>
           ))}

--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -12,7 +12,8 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 
 export default function MemberDashboard({
   onRequestReview = () => {},
-  onViewDetails = () => {},
+  onViewChargeDetails = () => {},
+  onViewPaymentDetails = () => {},
   pendingReviewIds = [],
   onShowAdmin,
 }) {
@@ -166,7 +167,7 @@ export default function MemberDashboard({
           <h2>Outstanding Charges</h2>
           <ChargeList
             charges={sortedOutstanding}
-            onViewDetails={onViewDetails}
+            onViewDetails={onViewChargeDetails}
             pendingReviewIds={pendingReviewIds}
             loading={loading}
           />
@@ -174,7 +175,11 @@ export default function MemberDashboard({
 
         <aside className="payments-section">
           <h2>Recent Payments</h2>
-          <PaymentList payments={sortedPayments} loading={loading} />
+          <PaymentList
+            payments={sortedPayments}
+            loading={loading}
+            onViewDetails={onViewPaymentDetails}
+          />
         </aside>
       </div>
     </div>

--- a/frontend/src/components/PaymentDetails.js
+++ b/frontend/src/components/PaymentDetails.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import '../styles/PaymentDetails.css';
+import SecondaryButton from './SecondaryButton';
+
+const samplePayment = {
+  id: 1,
+  amount: '$100',
+  date: '2024-05-01',
+  memo: 'Dues',
+  status: 'Approved',
+  adminNote: ''
+};
+
+export default function PaymentDetails({ payment, onBack }) {
+  const display = { ...samplePayment, ...(payment || {}) };
+  return (
+    <div className="payment-details-page">
+      <h1>Payment Details</h1>
+      <table className="payment-details-table">
+        <tbody>
+          <tr>
+            <th>Amount</th>
+            <td>{display.amount}</td>
+          </tr>
+          <tr>
+            <th>Paid On</th>
+            <td>{new Date(display.date).toLocaleDateString()}</td>
+          </tr>
+          <tr>
+            <th>Status</th>
+            <td>{display.status}</td>
+          </tr>
+          <tr>
+            <th>Memo</th>
+            <td>{display.memo || '-'}</td>
+          </tr>
+          <tr>
+            <th>Admin Note</th>
+            <td>{display.adminNote || '-'}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="payment-actions">
+        {onBack && (
+          <SecondaryButton type="button" onClick={onBack} className="back-button">
+            Back
+          </SecondaryButton>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PaymentList.js
+++ b/frontend/src/components/PaymentList.js
@@ -3,7 +3,7 @@ import DataTable from './DataTable';
 import '../styles/PaymentList.css';
 import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 
-export default function PaymentList({ payments = [], loading = false }) {
+export default function PaymentList({ payments = [], loading = false, onViewDetails = () => {} }) {
   if (!loading && payments.length === 0) {
     return (
       <div className="table-empty">
@@ -14,19 +14,22 @@ export default function PaymentList({ payments = [], loading = false }) {
   }
 
   const columns = [
-    { header: 'Amount Paid', accessor: 'amount' },
-    { header: 'Paid Date', accessor: 'paidDate' },
-    { header: 'Memo', accessor: 'memo' },
-    { header: 'Status', accessor: 'status' },
-    { header: 'Admin Note', accessor: 'adminNote' }
+    { header: 'Amount', accessor: 'amount' },
+    { header: 'Paid On', accessor: 'paidDate' },
+    { header: 'Status', accessor: 'status' }
   ];
 
   const rows = payments.map((p) => ({
     ...p,
     paidDate: new Date(p.date).toLocaleDateString(),
-    memo: p.memo || '-',
-    adminNote: p.adminNote || '-'
+    original: p
   }));
-
-  return <DataTable columns={columns} data={rows} loading={loading} />;
+  return (
+    <DataTable
+      columns={columns}
+      data={rows.map((r) => ({ ...r, amount: `$${r.amount}` }))}
+      loading={loading}
+      onRowClick={(row) => onViewDetails(row.original)}
+    />
+  );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,13 +5,11 @@
   --color-background: #F2F8FC;
   --color-text: #232d3d;
   --color-accent: #a7c6ea;
-  --color-accent-hover: #6b8aa8;
+  --color-accent-hover: #a2bacf;
   --color-surface: #F5F5F5;
   --color-surface-emphasis: #E0E0E0;
   --color-success: #4CAF50;
   --color-error: #B30000;
-  --color-navy: #1d2230;
-  --color-navy-dark: #121621;
   --space-xs: 4px;
   --space-sm: 8px;
   --space-md: 16px;

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -48,6 +48,11 @@
   border-spacing: 0 8px;
 }
 
+.admin-table thead th {
+  background: var(--color-surface-emphasis);
+  color: var(--color-text);
+}
+
 .admin-table th,
 .admin-table td {
   padding: 8px;
@@ -59,6 +64,16 @@
   border: 1px solid #ddd;
   border-radius: 6px;
   overflow: hidden;
+}
+
+.admin-table tbody tr.clickable-row {
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.admin-table tbody tr.clickable-row:hover {
+  transform: translateY(-2px);
+  background: var(--color-surface-emphasis);
 }
 
 .admin-table tbody tr td:first-child {

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -49,7 +49,7 @@
 }
 
 .admin-table thead th {
-  background: var(--color-navy-dark);
+  background: var(--color-text);
   color: white;
 }
 
@@ -60,8 +60,8 @@
 }
 
 .admin-table tbody tr {
-  background: var(--color-navy);
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-text);
   border: 1px solid #ddd;
   border-radius: 6px;
   overflow: hidden;
@@ -73,7 +73,7 @@
 }
 
 .admin-table tbody tr.clickable-row:hover {
-  background: var(--color-navy-dark);
+  background: var(--color-accent-hover);
 }
 
 .admin-table tbody tr td:first-child {

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -115,6 +115,15 @@
   padding: var(--space-sm);
 }
 
+.tables-section .admin-table tbody tr {
+  background: var(--color-text);
+  color: white;
+}
+
+.tables-section .admin-table tbody tr:hover {
+  background: #1d2230;
+}
+
 .payments-section {
   grid-column: span 4;
   /* removed temporary tinted background */

--- a/frontend/src/styles/PaymentDetails.css
+++ b/frontend/src/styles/PaymentDetails.css
@@ -1,0 +1,24 @@
+.payment-details-page {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.payment-details-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.payment-details-table th,
+.payment-details-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+.payment-actions {
+  display: flex;
+  gap: 10px;
+}


### PR DESCRIPTION
## Summary
- implement clickable table rows in `DataTable`
- show currency values with `$`
- restyle table header rows and add hover styles
- update member dashboard to use new charge/payment lists
- add payment details page
- adjust tests for new UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876f701638483288bed323be363623d