### PR TITLE
Update total balance color scheme

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,9 @@
 
 :root {
   --color-background: #F2F8FC;
-  --color-text: #282C34;
-  --color-accent: #a8d0ff;
-  --color-accent-hover: #82b4e5;
+  --color-text: #232d3d;
+  --color-accent: #a7c6ea;
+  --color-accent-hover: #6b8aa8;
   --color-surface: #F5F5F5;
   --color-surface-emphasis: #E0E0E0;
   --color-success: #4CAF50;

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -63,7 +63,7 @@
 
 .balance-card.total {
   background-color: var(--color-text);
-  border: 2px solid #fff;
+  border: 2px solid var(--color-accent);
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
   grid-column: 1 / -1;
   color: #fff;

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -62,10 +62,11 @@
 }
 
 .balance-card.total {
-  background-color: var(--color-surface-emphasis);
-  border: 2px solid var(--color-text);
+  background-color: var(--color-text);
+  border: 2px solid #fff;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
   grid-column: 1 / -1;
+  color: #fff;
 }
 
 .balance-card.overdue {


### PR DESCRIPTION
## Summary
- tweak Total Balance Due color palette so it matches the header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876f72204808328ae8c6a909ff8e460