### PR TITLE
Fix manage charges form grid layout

### DIFF
--- a/frontend/src/components/ManageCharges.js
+++ b/frontend/src/components/ManageCharges.js
@@ -145,7 +145,13 @@ export default function ManageCharges({ onBack }) {
               onChange={(e) => setDescription(e.target.value)}
               onBlur={handleDescriptionBlur}
             />
-            {descriptionError && <div className="error">{descriptionError}</div>}
+            <div
+              className={
+                descriptionError ? 'error' : 'error error-placeholder'
+              }
+            >
+              {descriptionError || '\u00a0'}
+            </div>
           </label>
           <label>
             Amount
@@ -162,7 +168,11 @@ export default function ManageCharges({ onBack }) {
                 }
               }}
             />
-            {amountError && <div className="error">{amountError}</div>}
+            <div
+              className={amountError ? 'error' : 'error error-placeholder'}
+            >
+              {amountError || '\u00a0'}
+            </div>
           </label>
           <label>
             Due Date

--- a/frontend/src/styles/ManageCharges.css
+++ b/frontend/src/styles/ManageCharges.css
@@ -61,4 +61,9 @@
   margin-left: 8px;
   font-size: 0.85rem;
   height: 100%;
+  min-width: 140px;
+}
+
+.error-placeholder {
+  visibility: hidden;
 }


### PR DESCRIPTION
## Summary
- preserve 3-column grid alignment for Manage Charges form
- hide placeholder error elements when no error text is present
- ensure field column does not shrink when errors appear

## Testing
- `npm --prefix frontend test --silent`
- `npm --prefix backend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68771876343c83288a55627aa5c578ee