### PR TITLE
Add arrow icon for clickable table rows

### DIFF
--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -70,6 +70,21 @@
 .admin-table tbody tr.clickable-row {
   cursor: pointer;
   transition: background 0.2s;
+  position: relative;
+}
+
+.admin-table tbody tr.clickable-row::after {
+  content: '›';
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-text);
+  pointer-events: none;
+}
+
+.admin-table tbody tr.clickable-row td:last-child {
+  padding-right: 20px;
 }
 
 .admin-table tbody tr.clickable-row:hover {


### PR DESCRIPTION
## Summary
- show a right arrow on `DataTable` rows that are clickable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687737da562883289a1fc0485ced4021