### PR TITLE
Display member name on dashboard

### DIFF
--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -111,7 +111,7 @@ export default function MemberDashboard({
         </div>
       )}
       <header className="member-dash-header">
-        <h1>Dashboard</h1>
+        <h1>{`Welcome${user?.name ? `, ${user.name}` : ''}!`}</h1>
       </header>
       <div className="balance-info" data-testid="balance-info">
         <div className="balance-summary">


### PR DESCRIPTION
## Summary
- personalize member dashboard header with member name
- run frontend test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877383a3b8083288be6da6b7ce430ca