### PR TITLE
Center content on payment review page

### DIFF
--- a/frontend/src/styles/PaymentReviewForm.css
+++ b/frontend/src/styles/PaymentReviewForm.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: 20px;
   padding: 20px;
+  align-items: center;
+  text-align: center;
 }
 
 .review-form {


### PR DESCRIPTION
## Summary
- tweak `PaymentReviewForm.css` to center items

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6877387e80708328856e28a5fc109da2