### PR TITLE
Add arrow indicator on DataTable row hover

### DIFF
--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -57,7 +57,7 @@ export default function DataTable({
                 return <td key={c.accessor}>{display}</td>;
               })}
               {renderActions && <td>{renderActions(row)}</td>}
-              {onRowClick && <td className="row-arrow">&#8594;</td>}
+              {onRowClick && <td className="row-arrow">&#x276F;</td>}
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -38,6 +38,7 @@ export default function DataTable({
               <th key={c.accessor}>{c.header}</th>
             ))}
             {renderActions && <th>Actions</th>}
+            {onRowClick && <th className="arrow-col" />}
           </tr>
         </thead>
         <tbody>
@@ -56,6 +57,7 @@ export default function DataTable({
                 return <td key={c.accessor}>{display}</td>;
               })}
               {renderActions && <td>{renderActions(row)}</td>}
+              {onRowClick && <td className="row-arrow">&#8594;</td>}
             </tr>
           ))}
         </tbody>

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -70,10 +70,27 @@
 .admin-table tbody tr.clickable-row {
   cursor: pointer;
   transition: background 0.2s;
+  position: relative;
 }
 
 .admin-table tbody tr.clickable-row:hover {
   background: var(--color-light-blue-hover);
+}
+
+.admin-table th.arrow-col {
+  width: 24px;
+}
+
+.admin-table td.row-arrow {
+  width: 24px;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.admin-table tbody tr.clickable-row:hover td.row-arrow {
+  opacity: 1;
 }
 
 .admin-table tbody tr td:first-child {


### PR DESCRIPTION
## Summary
- show a hover arrow so rows indicate they are clickable

## Testing
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68773a2f64c88328bd46effbb5719fc0