### PR TITLE
Add admin dashboard caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,15 @@ These keep common UI logic centralized so pages like `MembersList` and `ChargesL
 ## Documenting Database Schema Changes
 When implementing features that require new Supabase columns or tables, clearly describe the required schema updates in your pull request summary.
 Note any new column names, types and defaults so the Supabase instance can be updated accordingly.
+
+## Frontend Caching
+
+Both the member and admin dashboards cache frequently accessed API data in
+`localStorage` for five minutes. Cached keys:
+
+- `cachedCharges` and `cachedPayments` – member dashboard charges and payment
+  history.
+- `cachedPendingPayments` and `cachedAdminMembers` – admin dashboard payment
+  reviews and member names.
+
+The caches are cleared on logout in `AuthContext`.

--- a/frontend/src/AdminDashboard.test.js
+++ b/frontend/src/AdminDashboard.test.js
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import AdminDashboard from './components/AdminDashboard';
+import { AuthProvider } from './AuthContext';
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+test('uses cached data when available', async () => {
+  const ts = Date.now();
+  localStorage.setItem(
+    'cachedPendingPayments',
+    JSON.stringify({ ts, data: [{ id: 1, memberId: '1', amount: 10, date: '2024-05-01' }] })
+  );
+  localStorage.setItem(
+    'cachedAdminMembers',
+    JSON.stringify({ ts, data: [{ id: '1', name: 'Alice' }] })
+  );
+  global.fetch = jest.fn(() => new Promise(() => {}));
+  localStorage.setItem('authToken', 'token');
+  localStorage.setItem('authUser', JSON.stringify({ id: 1, isAdmin: true }));
+  render(
+    <AuthProvider>
+      <AdminDashboard />
+    </AuthProvider>
+  );
+  expect(await screen.findByText('Alice')).toBeInTheDocument();
+});
+
+test('api results refresh the cache', async () => {
+  const ts = Date.now();
+  localStorage.setItem(
+    'cachedPendingPayments',
+    JSON.stringify({ ts, data: [{ id: 1, memberId: '1', amount: 10, date: '2024-05-01' }] })
+  );
+  localStorage.setItem(
+    'cachedAdminMembers',
+    JSON.stringify({ ts, data: [{ id: '1', name: 'Alice' }] })
+  );
+  global.fetch = jest.fn((url) =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        if (url.includes('/payments?status=Under%20Review')) {
+          resolve({ ok: true, json: async () => [{ id: 1, memberId: '1', amount: 20, date: '2024-05-02' }] });
+        } else if (url.includes('/admin/members')) {
+          resolve({ ok: true, json: async () => [{ id: '1', name: 'Alice' }] });
+        } else {
+          resolve({ ok: true, json: async () => [] });
+        }
+      }, 0);
+    })
+  );
+  localStorage.setItem('authToken', 'token');
+  localStorage.setItem('authUser', JSON.stringify({ id: 1, isAdmin: true }));
+  render(
+    <AuthProvider>
+      <AdminDashboard />
+    </AuthProvider>
+  );
+  expect(await screen.findByText('$10')).toBeInTheDocument();
+  await waitFor(() => expect(screen.getByText('$20')).toBeInTheDocument());
+  expect(JSON.parse(localStorage.getItem('cachedPendingPayments')).data[0].amount).toBe(20);
+});
+

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -31,6 +31,8 @@ export function AuthProvider({ children }) {
       localStorage.removeItem('authToken');
       localStorage.removeItem('cachedCharges');
       localStorage.removeItem('cachedPayments');
+      localStorage.removeItem('cachedPendingPayments');
+      localStorage.removeItem('cachedAdminMembers');
     }
   }, [token]);
 

--- a/frontend/src/apiClient.js
+++ b/frontend/src/apiClient.js
@@ -68,8 +68,18 @@ export function useApi() {
       // Admin
       fetchMembers: (search = '') =>
         request(`/members?search=${encodeURIComponent(search)}`),
-      fetchAdminMembers: (search = '') =>
-        request(`/admin/members?search=${encodeURIComponent(search)}`),
+      fetchAdminMembers: async (search = '') => {
+        const data = await request(
+          `/admin/members?search=${encodeURIComponent(search)}`
+        );
+        if (!search && data) {
+          localStorage.setItem(
+            'cachedAdminMembers',
+            JSON.stringify({ ts: Date.now(), data })
+          );
+        }
+        return data;
+      },
       createMember: (member) =>
         request('/admin/members', {
           method: 'POST',
@@ -102,7 +112,16 @@ export function useApi() {
       deleteCharge: (id) =>
         request(`/admin/charges/${id}`, { method: 'DELETE' }),
 
-      fetchPendingPayments: () => request('/payments?status=Under%20Review'),
+      fetchPendingPayments: async () => {
+        const data = await request('/payments?status=Under%20Review');
+        if (data) {
+          localStorage.setItem(
+            'cachedPendingPayments',
+            JSON.stringify({ ts: Date.now(), data })
+          );
+        }
+        return data;
+      },
       approvePayment: (id) =>
         request(`/admin/payments/${id}/approve`, { method: 'POST' }),
       denyPayment: (id, note) =>


### PR DESCRIPTION
## Summary
- cache pending payments and member data for the admin dashboard
- clear admin cache entries on logout
- test admin dashboard caching
- document localStorage caches in AGENTS.md

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68773799d7ec832881793e17a9a21a23