### PR TITLE
Wrap payment review page in card

### DIFF
--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -58,11 +58,12 @@ export default function PaymentReviewForm({
 
   return (
     <div className="payment-review-page">
-      <h1>Payment Review</h1>
-      <form onSubmit={handleSubmit} className="review-form">
-        <div className="static-field">
-          <strong>Total Amount:</strong> {charge.amount}
-        </div>
+      <div className="review-card">
+        <h1>Payment Review</h1>
+        <form onSubmit={handleSubmit} className="review-form">
+          <div className="static-field">
+            <strong>Total Amount:</strong> {charge.amount}
+          </div>
         <label>
           Amount Paid
           <input
@@ -98,6 +99,7 @@ export default function PaymentReviewForm({
           )}
         </div>
       </form>
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/PaymentReviewForm.css
+++ b/frontend/src/styles/PaymentReviewForm.css
@@ -7,6 +7,18 @@
   text-align: center;
 }
 
+.review-card {
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 24px;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
 .review-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- enclose payment review form content in a new `review-card`
- add CSS for card styling

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68773a6010288328b82f1d127e5fa561