### PR TITLE
Add dark mode toggle with new theme variables

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -1,5 +1,5 @@
 import '../styles/App.css';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '../AuthContext';
 import LoginPage from './LoginPage';
 import MemberDashboard from './MemberDashboard';
@@ -20,6 +20,10 @@ function App() {
   const [detailsPayment, setDetailsPayment] = useState(null);
   const [pendingReviewIds, setPendingReviewIds] = useState([]);
   const [isAdminView, setIsAdminView] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  useEffect(() => {
+    document.body.classList.toggle('dark-mode', isDarkMode);
+  }, [isDarkMode]);
   const { token, setToken, setUser, user } = useAuth();
 
   const showMemberDashboard = () => {
@@ -63,6 +67,9 @@ function App() {
   const showAddMember = () => {
     setIsAdminView(true);
     setCurrentPage('addMember');
+  };
+  const toggleDarkMode = () => {
+    setIsDarkMode((v) => !v);
   };
   const showActivity = () => setCurrentPage('activity');
   const showReview = (charge) => {
@@ -161,6 +168,8 @@ function App() {
       onShowDashboard={token ? showDashboard : undefined}
       onShowActivity={token && !isAdminView ? showActivity : undefined}
       onLogout={token ? handleLogout : undefined}
+      isDarkMode={isDarkMode}
+      onToggleDarkMode={toggleDarkMode}
     >
       {pageContent}
     </AppShell>

--- a/frontend/src/components/AppShell.js
+++ b/frontend/src/components/AppShell.js
@@ -7,6 +7,8 @@ export default function AppShell({
   onShowDashboard,
   onShowActivity,
   onLogout,
+  isDarkMode,
+  onToggleDarkMode,
 }) {
   return (
     <div className="app-shell">
@@ -14,6 +16,8 @@ export default function AppShell({
         onShowDashboard={onShowDashboard}
         onShowActivity={onShowActivity}
         onLogout={onLogout}
+        isDarkMode={isDarkMode}
+        onToggleDarkMode={onToggleDarkMode}
       />
       <NotificationContainer />
       <main className="app-content">{children}</main>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,5 +1,6 @@
 import '../styles/Header.css';
 import PrimaryButton from './PrimaryButton';
+import ThemeToggle from './ThemeToggle';
 
 export default function Header({
   onShowLogin,
@@ -9,12 +10,15 @@ export default function Header({
   onShowChargeDetails,
   onShowActivity,
   onLogout,
+  isDarkMode,
+  onToggleDarkMode,
 }) {
   return (
     <header className="header">
       <nav className="nav">
         <span className="brand">Conclave ΣΧ-ΛΔ</span>
         <div className="nav-actions">
+          <ThemeToggle isDark={isDarkMode} onToggle={onToggleDarkMode} />
           {onShowLogin && (
             <PrimaryButton
               type="button"

--- a/frontend/src/components/ThemeToggle.js
+++ b/frontend/src/components/ThemeToggle.js
@@ -1,0 +1,26 @@
+import '../styles/ViewToggle.css';
+
+export default function ThemeToggle({ isDark = false, onToggle }) {
+  return (
+    <div className="view-toggle" role="group">
+      <button
+        type="button"
+        className={!isDark ? 'active' : ''}
+        onClick={() => {
+          if (isDark && onToggle) onToggle();
+        }}
+      >
+        Light
+      </button>
+      <button
+        type="button"
+        className={isDark ? 'active' : ''}
+        onClick={() => {
+          if (!isDark && onToggle) onToggle();
+        }}
+      >
+        Dark
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,8 @@
 :root {
   --color-offwhite: #F2F8FC;
   --color-navy: #232d3d;
+  --color-navy-bg: var(--color-navy);
+  --color-white-text: #fff;
   --color-light-blue: #a7c6ea;
   --color-light-blue-hover: #a2bacf;
   --color-light-gray: #F5F5F5;
@@ -15,6 +17,13 @@
   --space-md: 16px;
   --space-lg: 24px;
   --space-xl: 32px;
+}
+
+body.dark-mode {
+  --color-offwhite: #232d3d; /* offwhite backgrounds become navy */
+  --color-navy: #F2F8FC; /* navy text becomes offwhite */
+  --color-navy-bg: #a7c6ea; /* navy backgrounds become light blue */
+  --color-white-text: #232d3d; /* white text becomes navy */
 }
 
 body {

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -49,8 +49,8 @@
 }
 
 .admin-table thead th {
-  background: var(--color-navy);
-  color: white;
+  background: var(--color-navy-bg);
+  color: var(--color-white-text);
 }
 
 .admin-table th,

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -14,14 +14,14 @@
 }
 
 .App-header {
-  background-color: var(--color-navy);
+  background-color: var(--color-navy-bg);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
+  color: var(--color-white-text);
 }
 
 .App-link {

--- a/frontend/src/styles/Header.css
+++ b/frontend/src/styles/Header.css
@@ -1,7 +1,7 @@
 .header {
-  background-color: var(--color-navy);
+  background-color: var(--color-navy-bg);
   padding: 10px 20px;
-  color: white;
+  color: var(--color-white-text);
 }
 
 .nav {

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -62,11 +62,11 @@
 }
 
 .balance-card.total {
-  background-color: var(--color-navy);
+  background-color: var(--color-navy-bg);
   border: 2px solid var(--color-light-blue);
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
   grid-column: 1 / -1;
-  color: #fff;
+  color: var(--color-white-text);
 }
 
 .balance-card.overdue {

--- a/frontend/src/styles/Notifications.css
+++ b/frontend/src/styles/Notifications.css
@@ -10,7 +10,7 @@
 
 .notification {
   background-color: var(--color-success);
-  color: #fff;
+  color: var(--color-white-text);
   padding: 14px 36px 14px 18px;
   border-radius: 4px;
   min-width: 200px;
@@ -23,7 +23,7 @@
   right: 8px;
   background: transparent;
   border: none;
-  color: #fff;
+  color: var(--color-white-text);
   cursor: pointer;
   font-size: 1.4rem;
   line-height: 1;

--- a/frontend/src/styles/ViewToggle.css
+++ b/frontend/src/styles/ViewToggle.css
@@ -14,6 +14,6 @@
 }
 
 .view-toggle button.active {
-  background-color: var(--color-navy);
-  color: #fff;
+  background-color: var(--color-navy-bg);
+  color: var(--color-white-text);
 }


### PR DESCRIPTION
## Summary
- add a `ThemeToggle` component
- wire dark mode controls through `Header`, `AppShell`, and `App`
- define CSS variables for theme colors and dark mode overrides
- update existing styles to respect dark mode variables

## Testing
- `cd frontend && npm run test:coverage`
- `cd ../backend && npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68773aef2e848328be2b067d6293987a