### PR TITLE
Display full charge details

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -150,6 +150,7 @@ app.get('/api/my-charges', auth, async (req, res) => {
     description: row.description,
     tags: row.tags,
     partialAmountPaid: row.partial_amount_paid || 0,
+    updatedAt: row.updated_at
   }));
 
   res.json(mapped);

--- a/backend/routes/charges.js
+++ b/backend/routes/charges.js
@@ -23,6 +23,8 @@ router.get('/', async (req, res) => {
     dueDate: row.due_date,
     description: row.description,
     tags: row.tags,
+    partialAmountPaid: row.partial_amount_paid || 0,
+    updatedAt: row.updated_at,
   }));
 
   res.json(mapped);

--- a/frontend/src/components/ChargeDetails.js
+++ b/frontend/src/components/ChargeDetails.js
@@ -5,13 +5,19 @@ import SecondaryButton from './SecondaryButton';
 const sampleCharge = {
   id: 1,
   status: 'Outstanding',
-  amount: '$500',
+  amount: 500,
+  partialAmountPaid: 0,
   dueDate: '2024-05-01',
   description: 'Semester dues',
+  updatedAt: '2024-05-01',
 };
 
 export default function ChargeDetails({ charge, onRequestReview, onBack }) {
   const displayCharge = { ...sampleCharge, ...(charge || {}) };
+  const statusDisplay =
+    displayCharge.partialAmountPaid > 0
+      ? `${displayCharge.status} ($${displayCharge.partialAmountPaid})`
+      : displayCharge.status;
 
   return (
     <div className="charge-details-page">
@@ -21,11 +27,11 @@ export default function ChargeDetails({ charge, onRequestReview, onBack }) {
         <tbody>
           <tr>
             <th>Status</th>
-            <td>{displayCharge.status}</td>
+            <td>{statusDisplay}</td>
           </tr>
           <tr>
             <th>Amount</th>
-            <td>{displayCharge.amount}</td>
+            <td>{`$${displayCharge.amount}`}</td>
           </tr>
           <tr>
             <th>Due Date</th>
@@ -34,6 +40,14 @@ export default function ChargeDetails({ charge, onRequestReview, onBack }) {
           <tr>
             <th>Description</th>
             <td>{displayCharge.description || '-'}</td>
+          </tr>
+          <tr>
+            <th>Last Updated</th>
+            <td>
+              {displayCharge.updatedAt
+                ? new Date(displayCharge.updatedAt).toLocaleString()
+                : '-'}
+            </td>
           </tr>
         </tbody>
       </table>

--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -42,7 +42,10 @@ export default function ChargeList({
       amount: charge.amount,
       dueDate: new Date(charge.dueDate).toLocaleDateString(),
       statusDisplay,
-      original: charge
+      original: {
+        ...charge,
+        description: charge.description || '-',
+      }
     };
   });
 
@@ -56,7 +59,10 @@ export default function ChargeList({
           id: row.original.id,
           status: row.original.status,
           amount: row.original.amount,
-          dueDate: row.original.dueDate
+          dueDate: row.original.dueDate,
+          description: row.original.description,
+          partialAmountPaid: row.original.partialAmountPaid,
+          updatedAt: row.original.updatedAt
         })
       }
     />


### PR DESCRIPTION
## Summary
- expose `updatedAt` for charges on the backend
- include more properties when selecting a charge
- show partial payments and last updated on Charge Details page

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68773cd0ca1c8328b37da859b8c3b01f