### PR TITLE
Fix login button width on loading

### DIFF
--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -67,12 +67,9 @@ export default function LoginPage({ onLogin = () => {} }) {
             placeholder="Password"
           />
           {error && <div className="error">{error}</div>}
-          <PrimaryButton type="submit" disabled={loading}>
-            {loading ? (
-              <span className="spinner" aria-label="loading" />
-            ) : (
-              'Login'
-            )}
+          <PrimaryButton type="submit" disabled={loading} className="login-button">
+            <span className={loading ? 'hidden-text' : undefined}>Login</span>
+            {loading && <span className="spinner" aria-label="loading" />}
           </PrimaryButton>
         </form>
         <a href="#" className="forgot-link">

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -97,6 +97,21 @@ button:disabled {
   animation: spin 1s linear infinite;
 }
 
+.login-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-button .hidden-text {
+  visibility: hidden;
+}
+
+.login-button .spinner {
+  position: absolute;
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);


### PR DESCRIPTION
## Summary
- keep login button width stable while showing loading state

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68773e5a4dfc83289ddfaba05e273b9a