### PR TITLE
Fix admin cache loading

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -52,8 +52,10 @@ export default function AdminDashboard({
     if (usedCache) {
       setLoading(false);
     }
-    async function load() {
-      setLoading(true);
+    async function load(skipLoading) {
+      if (!skipLoading) {
+        setLoading(true);
+      }
       try {
         const [r, m] = await Promise.all([
           api.fetchPendingPayments(),
@@ -83,7 +85,7 @@ export default function AdminDashboard({
         setLoading(false);
       }
     }
-    load();
+    load(usedCache);
   }, []);
 
   function openApproveDialog(review) {


### PR DESCRIPTION
## Summary
- avoid showing spinner when cached data is used on the admin dashboard

## Testing
- `npm run test:coverage` in `frontend`
- `npm run test:coverage` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68773ebed5d48328938d80a0f9883ba0