### PR TITLE
Add visual status indicators

### DIFF
--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -4,6 +4,7 @@ import '../styles/ChargeList.css';
 import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 import PrimaryButton from './PrimaryButton';
 import SecondaryButton from './SecondaryButton';
+import { getStatusCategory } from '../statusUtils';
 
 export default function ChargeList({
   charges = [],
@@ -29,19 +30,24 @@ export default function ChargeList({
     { header: 'Description', accessor: 'description' },
     { header: 'Amount', accessor: 'amount' },
     { header: 'Due Date', accessor: 'dueDate' },
-    { header: 'Status', accessor: 'statusDisplay' }
+    { header: 'Status', accessor: 'statusDisplay' },
+    { header: '', accessor: 'statusIndicator' }
   ];
 
   const rows = visible.map((charge) => {
     const pending = pendingReviewIds.includes(charge.id);
     const effectiveStatus = pending ? 'Under Review' : charge.status;
     const statusDisplay = effectiveStatus;
+    const statusIndicator = (
+      <span className={`status-circle ${getStatusCategory(effectiveStatus)}`} />
+    );
     return {
       id: charge.id,
       description: charge.description || '-',
       amount: charge.amount,
       dueDate: new Date(charge.dueDate).toLocaleDateString(),
       statusDisplay,
+      statusIndicator,
       original: charge
     };
   });

--- a/frontend/src/components/PaymentList.js
+++ b/frontend/src/components/PaymentList.js
@@ -2,6 +2,7 @@ import React from 'react';
 import DataTable from './DataTable';
 import '../styles/PaymentList.css';
 import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
+import { getStatusCategory } from '../statusUtils';
 
 export default function PaymentList({ payments = [], loading = false, onViewDetails = () => {} }) {
   if (!loading && payments.length === 0) {
@@ -16,12 +17,16 @@ export default function PaymentList({ payments = [], loading = false, onViewDeta
   const columns = [
     { header: 'Amount', accessor: 'amount' },
     { header: 'Paid On', accessor: 'paidDate' },
-    { header: 'Status', accessor: 'status' }
+    { header: 'Status', accessor: 'status' },
+    { header: '', accessor: 'statusIndicator' }
   ];
 
   const rows = payments.map((p) => ({
     ...p,
     paidDate: new Date(p.date).toLocaleDateString(),
+    statusIndicator: (
+      <span className={`status-circle ${getStatusCategory(p.status)}`} />
+    ),
     original: p
   }));
   return (

--- a/frontend/src/statusUtils.js
+++ b/frontend/src/statusUtils.js
@@ -1,0 +1,7 @@
+export function getStatusCategory(status) {
+  if (!status) return 'neutral';
+  const s = status.toLowerCase();
+  if (s.includes('denied') || s.includes('delinq')) return 'bad';
+  if (s.includes('paid') || s.includes('approved')) return 'good';
+  return 'neutral';
+}

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -175,3 +175,19 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.status-circle {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.status-circle.good {
+  background-color: var(--color-success);
+}
+.status-circle.bad {
+  background-color: var(--color-error);
+}
+.status-circle.neutral {
+  background-color: var(--color-light-gray);
+}


### PR DESCRIPTION
## Summary
- create `getStatusCategory` helper for mapping status strings
- display colored status circles in ChargeList and PaymentList
- style new circle indicators in AdminDashboard.css

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68773f1d7de08328bb8156b1b1d93a4e