### PR TITLE
Add platform dropdown for payment submissions

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -240,16 +240,20 @@ app.get('/api/payments', auth, async (req, res) => {
       memo: p.memo,
       status: p.status,
       adminId: p.admin_id,
-      adminNote: p.admin_note
+      adminNote: p.admin_note,
+      platform: p.platform
     }))
   );
 });
 
 // Submit a payment for review
 app.post('/api/payments', auth, async (req, res) => {
-  const { amount, memo, date } = req.body || {};
+  const { amount, memo, date, platform } = req.body || {};
   if (amount == null) {
     return res.status(400).json({ error: 'Missing amount' });
+  }
+  if (!platform) {
+    return res.status(400).json({ error: 'Missing platform' });
   }
 
   // record the payment first
@@ -260,6 +264,7 @@ app.post('/api/payments', auth, async (req, res) => {
       amount,
       date: date || new Date().toISOString().slice(0, 10),
       memo: memo || '',
+      platform,
       status: 'Under Review',
       admin_note: ''
     })

--- a/backend/test/admin_crud.test.js
+++ b/backend/test/admin_crud.test.js
@@ -133,7 +133,7 @@ test('admin can deny a payment request', async () => {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${memberToken}`
     },
-    body: JSON.stringify({ amount: 5 })
+    body: JSON.stringify({ amount: 5, platform: 'Zelle' })
   });
   assert.equal(reviewRes.status, 200);
 

--- a/backend/test/index.test.js
+++ b/backend/test/index.test.js
@@ -66,7 +66,7 @@ test('payment submission validates fields', async () => {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`
     },
-    body: JSON.stringify({})
+    body: JSON.stringify({ amount: 5 })
   });
   assert.equal(res.status, 400);
 });
@@ -78,7 +78,7 @@ test('submit payment succeeds', async () => {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`
     },
-    body: JSON.stringify({ amount: 100, memo: 'Test' })
+    body: JSON.stringify({ amount: 100, memo: 'Test', platform: 'Zelle' })
   });
   assert.equal(res.status, 200);
   const data = await res.json();
@@ -155,7 +155,7 @@ test('admin can approve payment', async () => {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`
     },
-  body: JSON.stringify({ amount: 250 })
+  body: JSON.stringify({ amount: 250, platform: 'Zelle' })
   });
   assert.equal(res.status, 200);
 

--- a/backend/test/payment_flow.test.js
+++ b/backend/test/payment_flow.test.js
@@ -83,7 +83,7 @@ async function submitPayment(amount) {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${memberToken}`
     },
-    body: JSON.stringify({ amount })
+    body: JSON.stringify({ amount, platform: 'Zelle' })
   });
   const data = await res.json();
   return data.payment.id;

--- a/backend/test/supabaseMock.js
+++ b/backend/test/supabaseMock.js
@@ -43,7 +43,8 @@ let payments = [
     memo: 'Dues',
     status: 'Approved',
     admin_id: profiles[1].id,
-    admin_note: ''
+    admin_note: '',
+    platform: 'Zelle'
   }
 ];
 let nextPaymentId = 2;

--- a/frontend/src/PaymentReviewForm.test.js
+++ b/frontend/src/PaymentReviewForm.test.js
@@ -23,6 +23,7 @@ test('successful submit shows confirmation message', async () => {
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
   );
+  await userEvent.selectOptions(screen.getByLabelText(/platform/i), 'Zelle');
   const input = screen.getByLabelText(/amount paid/i);
   expect(input).toHaveValue(100);
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
@@ -39,6 +40,7 @@ test('failed submit shows error message', async () => {
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
   );
+  await userEvent.selectOptions(screen.getByLabelText(/platform/i), 'Zelle');
   const input = screen.getByLabelText(/amount paid/i);
   await userEvent.clear(input);
   await userEvent.type(input, '50');
@@ -46,13 +48,14 @@ test('failed submit shows error message', async () => {
   expect(await screen.findByText('Bad request')).toBeInTheDocument();
 });
 
-test('prefills amount for lump sum payment', () => {
+test('prefills amount for lump sum payment', async () => {
   setupLocalStorage();
   render(
     <AuthProvider>
       <PaymentReviewForm charge={{ amount: 250 }} />
     </AuthProvider>
   );
+  await userEvent.selectOptions(screen.getByLabelText(/platform/i), 'Zelle');
   const input = screen.getByLabelText(/amount paid/i);
   expect(input).toHaveValue(250);
 });
@@ -64,11 +67,26 @@ test('shows error on overpayment', async () => {
       <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
     </AuthProvider>
   );
+  await userEvent.selectOptions(screen.getByLabelText(/platform/i), 'Zelle');
   const input = screen.getByLabelText(/amount paid/i);
   await userEvent.clear(input);
   await userEvent.type(input, '150');
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(
     await screen.findByText(/exceeds outstanding charges/i)
+  ).toBeInTheDocument();
+});
+
+test('requires custom platform when other selected', async () => {
+  setupLocalStorage();
+  render(
+    <AuthProvider>
+      <PaymentReviewForm charge={{ id: 1, amount: 100 }} />
+    </AuthProvider>
+  );
+  await userEvent.selectOptions(screen.getByLabelText(/platform/i), 'Other');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(
+    await screen.findByText(/payment platform is required/i)
   ).toBeInTheDocument();
 });

--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -17,6 +17,8 @@ export default function PaymentReviewForm({
   const [paymentDate, setPaymentDate] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [platform, setPlatform] = useState('');
+  const [otherPlatform, setOtherPlatform] = useState('');
   const api = useApi();
   const { addNotification } = useNotifications();
 
@@ -34,6 +36,11 @@ export default function PaymentReviewForm({
     e.preventDefault();
     setError('');
     setMessage('');
+    const plat = platform === 'Other' ? otherPlatform.trim() : platform;
+    if (!plat) {
+      setError('Payment platform is required');
+      return;
+    }
     if (Number(amountPaid) > Number(charge.amount)) {
       setError('Payment exceeds outstanding charges');
       return;
@@ -43,11 +50,14 @@ export default function PaymentReviewForm({
         amount: amountPaid,
         memo,
         date: paymentDate
+        , platform: plat
       });
       setMessage('Payment submitted');
       setMemo('');
       setAmountPaid('');
       setPaymentDate('');
+      setPlatform('');
+      setOtherPlatform('');
       addNotification('Your payment review has been submitted successfully.');
       if (onSubmitted) onSubmitted(charge?.id);
       if (onBack) onBack();
@@ -80,6 +90,27 @@ export default function PaymentReviewForm({
             onChange={(e) => setPaymentDate(e.target.value)}
           />
         </label>
+        <label>
+          Platform
+          <select value={platform} onChange={(e) => setPlatform(e.target.value)}>
+            <option value="" disabled>Select one</option>
+            <option value="Zelle">Zelle</option>
+            <option value="Venmo">Venmo</option>
+            <option value="Debit/Credit">Debit/Credit</option>
+            <option value="Cash">Cash</option>
+            <option value="Other">Other</option>
+          </select>
+        </label>
+        {platform === 'Other' && (
+          <label>
+            Specify Platform
+            <input
+              type="text"
+              value={otherPlatform}
+              onChange={(e) => setOtherPlatform(e.target.value)}
+            />
+          </label>
+        )}
         <label>
           Memo
           <input

--- a/frontend/src/styles/PaymentReviewForm.css
+++ b/frontend/src/styles/PaymentReviewForm.css
@@ -36,6 +36,10 @@
   padding: 8px;
   font-size: 1rem;
 }
+.review-form select {
+  padding: 8px;
+  font-size: 1rem;
+}
 
 .form-actions {
   display: flex;


### PR DESCRIPTION
## Summary
- require payment `platform` column in backend API
- support new `platform` field in payment review form with "Other" text box
- style dropdown to match inputs
- update backend and frontend tests for platform requirement

Database schema change: `payments.platform` text column should be added (non-null)

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6877c413df20832899e4fe9d0647de03