### PR TITLE
Disable payment submit while loading

### DIFF
--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -20,6 +20,7 @@ export default function PaymentReviewForm({
   const [error, setError] = useState('');
   const [platform, setPlatform] = useState('');
   const [otherPlatform, setOtherPlatform] = useState('');
+  const [loading, setLoading] = useState(false);
   const api = useApi();
   const { addNotification } = useNotifications();
 
@@ -48,6 +49,7 @@ export default function PaymentReviewForm({
     e.preventDefault();
     setError('');
     setMessage('');
+    setLoading(true);
     const plat = platform === 'Other' ? otherPlatform.trim() : platform;
     if (!plat) {
       setError('Payment platform is required');
@@ -79,6 +81,8 @@ export default function PaymentReviewForm({
       if (onBack) onBack();
     } catch (err) {
       setError(err.message);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -140,7 +144,14 @@ export default function PaymentReviewForm({
         {error && <div className="error">{error}</div>}
         {message && <div className="success">{message}</div>}
         <div className="form-actions">
-          <PrimaryButton type="submit">Submit</PrimaryButton>
+          <PrimaryButton
+            type="submit"
+            disabled={loading}
+            className="submit-button"
+          >
+            <span className={loading ? 'hidden-text' : undefined}>Submit</span>
+            {loading && <span className="spinner" aria-label="loading" />}
+          </PrimaryButton>
           {onBack && (
             <SecondaryButton type="button" onClick={onBack} className="back-button">
               Back

--- a/frontend/src/styles/PaymentReviewForm.css
+++ b/frontend/src/styles/PaymentReviewForm.css
@@ -63,3 +63,37 @@
   font-size: 0.75rem;
   color: #555;
 }
+
+.spinner {
+  border: 2px solid #ccc;
+  border-top: 2px solid #333;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+.submit-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.submit-button .hidden-text {
+  visibility: hidden;
+}
+
+.submit-button .spinner {
+  position: absolute;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- disable payment review submission button while the request is in progress
- add spinner styles to PaymentReviewForm and update button markup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877cd64bdcc8328baf1405a2646d795