### PR TITLE
Add platform row to payment details page

### DIFF
--- a/frontend/src/PaymentDetails.test.js
+++ b/frontend/src/PaymentDetails.test.js
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import PaymentDetails from './components/PaymentDetails';
+
+test('shows payment platform in details', () => {
+  const payment = {
+    amount: 50,
+    date: '2025-01-01',
+    status: 'Approved',
+    memo: 'Dues',
+    adminNote: '',
+    platform: 'Venmo'
+  };
+  render(<PaymentDetails payment={payment} />);
+  expect(screen.getByText(/venmo/i)).toBeInTheDocument();
+});

--- a/frontend/src/components/PaymentDetails.js
+++ b/frontend/src/components/PaymentDetails.js
@@ -8,6 +8,7 @@ const samplePayment = {
   date: '2024-05-01',
   memo: 'Dues',
   status: 'Approved',
+  platform: 'Zelle',
   adminNote: ''
 };
 
@@ -25,6 +26,10 @@ export default function PaymentDetails({ payment, onBack }) {
           <tr>
             <th>Paid On</th>
             <td>{new Date(display.date).toLocaleDateString()}</td>
+          </tr>
+          <tr>
+            <th>Platform</th>
+            <td>{display.platform || '-'}</td>
           </tr>
           <tr>
             <th>Status</th>


### PR DESCRIPTION
## Summary
- show payment platform alongside status, memo, and admin note
- add regression test for PaymentDetails component

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6877ccfca1808328bc73ec6532dbe4ec