### PR TITLE
Improve navigation with navbar tabs

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -140,18 +140,6 @@ export default function AdminDashboard({
         <h1>Admin Dashboard</h1>
       </header>
       {error && <div className="error">{error}</div>}
-      <section className="quick-links">
-        <PrimaryButton className="quick-link" onClick={onManageCharges}>
-          Manage Charges
-          <span className="desc">Create, update, or delete charges for members</span>
-        </PrimaryButton>
-        <PrimaryButton className="quick-link" onClick={onShowMembers}>
-          Manage Members
-          <span className="desc">
-            Add, browse, and manage all member accounts
-          </span>
-        </PrimaryButton>
-      </section>
       <section>
         <h2>Payment Reviews</h2>
         <DataTable

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -160,7 +160,10 @@ function App() {
     <AppShell
       onShowDashboard={token ? showDashboard : undefined}
       onShowActivity={token && !isAdminView ? showActivity : undefined}
+      onShowManageCharges={token && isAdminView ? showManageCharges : undefined}
+      onShowMembers={token && isAdminView ? showMembersList : undefined}
       onLogout={token ? handleLogout : undefined}
+      currentPage={currentPage}
     >
       {pageContent}
     </AppShell>

--- a/frontend/src/components/AppShell.js
+++ b/frontend/src/components/AppShell.js
@@ -6,14 +6,20 @@ export default function AppShell({
   children,
   onShowDashboard,
   onShowActivity,
+  onShowManageCharges,
+  onShowMembers,
   onLogout,
+  currentPage,
 }) {
   return (
     <div className="app-shell">
       <Header
         onShowDashboard={onShowDashboard}
         onShowActivity={onShowActivity}
+        onShowManageCharges={onShowManageCharges}
+        onShowMembers={onShowMembers}
         onLogout={onLogout}
+        currentPage={currentPage}
       />
       <NotificationContainer />
       <main className="app-content">{children}</main>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,77 +1,67 @@
 import '../styles/Header.css';
 import PrimaryButton from './PrimaryButton';
+import NavTab from './NavTab';
 
 export default function Header({
   onShowLogin,
   onShowDashboard,
-  onShowAdmin,
-  onShowReview,
-  onShowChargeDetails,
   onShowActivity,
+  onShowManageCharges,
+  onShowMembers,
   onLogout,
+  currentPage,
 }) {
   return (
     <header className="header">
       <nav className="nav">
         <span className="brand">Conclave ΣΧ-ΛΔ</span>
-        <div className="nav-actions">
-          {onShowLogin && (
-            <PrimaryButton
-              type="button"
-              className="nav-button login-nav-button"
-              onClick={onShowLogin}
-            >
-              Login
-            </PrimaryButton>
-          )}
+        <div className="nav-tabs">
           {onShowDashboard && (
-            <PrimaryButton
-              type="button"
-              className="nav-button dashboard-nav-button"
+            <NavTab
+              className="dashboard-tab"
+              active={currentPage === 'dashboard' || currentPage === 'admin'}
               onClick={onShowDashboard}
             >
               Dashboard
-            </PrimaryButton>
+            </NavTab>
           )}
           {onShowActivity && (
-            <PrimaryButton
-              type="button"
-              className="nav-button activity-nav-button"
+            <NavTab
+              className="activity-tab"
+              active={currentPage === 'activity'}
               onClick={onShowActivity}
             >
               Account Activity
-            </PrimaryButton>
+            </NavTab>
           )}
-          {onShowAdmin && (
-            <PrimaryButton
-              type="button"
-              className="nav-button admin-nav-button"
-              onClick={onShowAdmin}
+          {onShowManageCharges && (
+            <NavTab
+              className="charges-tab"
+              active={currentPage === 'manageCharges'}
+              onClick={onShowManageCharges}
             >
-              Admin
-            </PrimaryButton>
+              Manage Charges
+            </NavTab>
           )}
-          {onShowReview && (
-            <PrimaryButton
-              type="button"
-              className="nav-button review-nav-button"
-              onClick={onShowReview}
+          {onShowMembers && (
+            <NavTab
+              className="members-tab"
+              active={currentPage === 'members'}
+              onClick={onShowMembers}
             >
-              Payment Review
-            </PrimaryButton>
+              Manage Members
+            </NavTab>
           )}
-          {onShowChargeDetails && (
-            <PrimaryButton
-              type="button"
-              className="nav-button charge-details-nav-button"
-              onClick={onShowChargeDetails}
-            >
-              Charge Details
-            </PrimaryButton>
-          )}
+        </div>
+        <div className="nav-actions">
           {onLogout && (
-            <PrimaryButton type="button" className="nav-button logout-button" onClick={onLogout}>
+            <PrimaryButton type="button" className="logout-button" onClick={onLogout}>
               Logout
+            </PrimaryButton>
+          )}
+          {onShowLogin && (
+            <PrimaryButton type="button" onClick={onShowLogin}>
+              Login
             </PrimaryButton>
           )}
         </div>

--- a/frontend/src/components/NavTab.js
+++ b/frontend/src/components/NavTab.js
@@ -1,0 +1,13 @@
+import '../styles/NavTab.css';
+
+export default function NavTab({ active = false, children, className = '', ...props }) {
+  return (
+    <button
+      className={`nav-tab ${active ? 'active' : ''} ${className}`.trim()}
+      type="button"
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -11,28 +11,6 @@
   gap: 12px;
 }
 
-.quick-links {
-  flex-direction: row;
-}
-
-.quick-link {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 10px 14px;
-  border: 1px solid #ddd;
-  background: var(--color-light-gray);
-  cursor: pointer;
-}
-
-.quick-link:disabled {
-  cursor: default;
-  opacity: 0.7;
-}
-
-.quick-link .desc {
-  font-size: 0.8rem;
-}
 
 .admin-dash-header {
   display: flex;

--- a/frontend/src/styles/Header.css
+++ b/frontend/src/styles/Header.css
@@ -6,7 +6,6 @@
 
 .nav {
   display: flex;
-  justify-content: space-between;
   align-items: center;
 }
 
@@ -21,11 +20,14 @@
 }
 
 .nav-actions {
+  margin-left: auto;
   display: flex;
   gap: 8px;
   align-items: center;
 }
 
-.nav-button {
-  padding: 5px 10px;
+.nav-tabs {
+  display: flex;
+  gap: 8px;
+  margin-left: 20px;
 }

--- a/frontend/src/styles/NavTab.css
+++ b/frontend/src/styles/NavTab.css
@@ -1,0 +1,18 @@
+.nav-tab {
+  padding: 6px 12px;
+  background-color: var(--color-light-gray);
+  color: var(--color-navy);
+  border: 1px solid var(--color-light-gray-hover);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  cursor: pointer;
+}
+
+.nav-tab:hover {
+  background-color: var(--color-light-gray-hover);
+}
+
+.nav-tab.active {
+  background-color: var(--color-offwhite);
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add `NavTab` component for tab-like navigation
- hook new tabs into header and restructure layout
- pass current page and handlers through `AppShell`
- remove admin quick-links since tabs cover that functionality

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6877d75e36408328b0ebe290b6516a14