### PR TITLE
Add platform column and row click to admin payment reviews

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -13,7 +13,8 @@ const DENY_NOTE_LIMIT = 70;
 export default function AdminDashboard({
   onManageCharges,
   onShowMembers,
-  onShowMemberDashboard
+  onShowMemberDashboard,
+  onViewPaymentDetails
 }) {
   const api = useApi();
   const [reviews, setReviews] = useState([]);
@@ -160,6 +161,7 @@ export default function AdminDashboard({
             { header: 'Member', accessor: 'member' },
             { header: 'Amount Paid', accessor: 'amount' },
             { header: 'Payment Date', accessor: 'date' },
+            { header: 'Platform', accessor: 'platform' },
             { header: 'Memo', accessor: 'memo' }
           ]}
           data={reviews.map((r) => ({
@@ -167,6 +169,7 @@ export default function AdminDashboard({
             member: members[r.memberId] || r.memberId,
             amount: r.amountPaid ?? r.amount,
             date: new Date(r.date).toLocaleDateString(),
+            platform: r.platform || '-',
             memo: r.memo || '-',
             original: r
           }))}
@@ -180,6 +183,11 @@ export default function AdminDashboard({
               </SecondaryButton>
             </div>
           )}
+          onRowClick={
+            onViewPaymentDetails
+              ? (row) => onViewPaymentDetails(row.original)
+              : undefined
+          }
         />
       </section>
       <ConfirmDialog

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -138,6 +138,7 @@ function App() {
           onManageCharges={showManageCharges}
           onShowMembers={showMembersList}
           onShowMemberDashboard={showMemberDashboard}
+          onViewPaymentDetails={showPaymentDetails}
         />
       );
       break;


### PR DESCRIPTION
## Summary
- display payment platform column in admin dashboard
- allow clicking a review row to open payment details

## Testing
- `npm run test:coverage` in `frontend`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6877dac14fd483289101788c9d9d6f6d