### PR TITLE
Lower char limits

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -8,7 +8,7 @@ import PrimaryButton from './PrimaryButton';
 import SecondaryButton from './SecondaryButton';
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
-const DENY_NOTE_LIMIT = 70;
+const DENY_NOTE_LIMIT = 50;
 
 export default function AdminDashboard({
   onManageCharges,

--- a/frontend/src/components/ManageCharges.js
+++ b/frontend/src/components/ManageCharges.js
@@ -9,7 +9,7 @@ import PrimaryButton from './PrimaryButton';
 import SecondaryButton from './SecondaryButton';
 
 const STATUS_OPTIONS = ['Active', 'Alumni', 'Inactive', 'Suspended', 'Expelled'];
-const MAX_DESC_LENGTH = 70;
+const MAX_DESC_LENGTH = 50;
 
 export default function ManageCharges({ onBack }) {
   const api = useApi();

--- a/frontend/src/components/PaymentReviewForm.js
+++ b/frontend/src/components/PaymentReviewForm.js
@@ -24,7 +24,7 @@ export default function PaymentReviewForm({
   const api = useApi();
   const { addNotification } = useNotifications();
 
-  const MEMO_LIMIT = 70;
+  const MEMO_LIMIT = 50;
 
   useEffect(() => {
     if (charge && (charge.id || charge.amount)) {


### PR DESCRIPTION
## Summary
- limit memos, descriptions and denial notes to 50 characters

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6877f2e2168c8328ba8adb9ce6f66a4b