### PR TITLE
Keep logout button layout stable

### DIFF
--- a/frontend/src/AppNavigation.test.js
+++ b/frontend/src/AppNavigation.test.js
@@ -78,5 +78,5 @@ test('user can view payment details from dashboard', async () => {
   expect(
     await screen.findByRole('heading', { name: /payment details/i })
   ).toBeInTheDocument();
-  expect(screen.getByText('50')).toBeInTheDocument();
+  expect(screen.getByText('$50')).toBeInTheDocument();
 });

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -64,11 +64,15 @@ export default function Header({
           )}
         </div>
         <div className="nav-actions">
-          {onLogout && (
-            <PrimaryButton type="button" className="logout-button" onClick={onLogout}>
-              Logout
-            </PrimaryButton>
-          )}
+          <PrimaryButton
+            type="button"
+            className="logout-button"
+            onClick={onLogout}
+            style={{ visibility: onLogout ? 'visible' : 'hidden' }}
+            disabled={!onLogout}
+          >
+            Logout
+          </PrimaryButton>
           {onShowLogin && (
             <PrimaryButton type="button" onClick={onShowLogin}>
               Login


### PR DESCRIPTION
## Summary
- hide logout button using `visibility: hidden` when not applicable so navbar width stays consistent
- update dashboard navigation test after `$50` formatting

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877f511c76c8328b72b7f87a494e78e