### PR TITLE
Add Forgot Email popup

### DIFF
--- a/frontend/src/LoginPage.test.js
+++ b/frontend/src/LoginPage.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginPage from './components/LoginPage';
+
+// simple test to ensure the forgot email link opens the dialog
+
+test('forgot email link opens help dialog', async () => {
+  render(<LoginPage />);
+  const link = screen.getByRole('link', { name: /forgot email/i });
+  await userEvent.click(link);
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+});

--- a/frontend/src/components/InfoDialog.js
+++ b/frontend/src/components/InfoDialog.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import '../styles/ConfirmDialog.css';
+import PrimaryButton from './PrimaryButton';
+
+export default function InfoDialog({ open = false, title = '', children, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="confirm-dialog-overlay" role="dialog" aria-modal="true">
+      <div className="confirm-dialog">
+        <header className="confirm-dialog-header">
+          <h2>{title}</h2>
+          <button
+            type="button"
+            className="confirm-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </header>
+        <div className="confirm-dialog-body">{children}</div>
+        <div className="confirm-dialog-actions">
+          <PrimaryButton type="button" onClick={onClose} className="confirm-button">
+            Close
+          </PrimaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -4,6 +4,7 @@ import useApi from '../apiClient';
 import { useAuth } from '../AuthContext';
 import { supabase } from '../supabaseClient';
 import PrimaryButton from './PrimaryButton';
+import InfoDialog from './InfoDialog';
 import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 
 export default function LoginPage({ onLogin = () => {} }) {
@@ -11,6 +12,7 @@ export default function LoginPage({ onLogin = () => {} }) {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showEmailHelp, setShowEmailHelp] = useState(false);
   const { setToken, setUser } = useAuth();
   const api = useApi();
 
@@ -72,9 +74,28 @@ export default function LoginPage({ onLogin = () => {} }) {
             {loading && <span className="spinner" aria-label="loading" />}
           </PrimaryButton>
         </form>
-        <a href="#" className="forgot-link">
-          Forgot Password?
-        </a>
+        <div className="forgot-links">
+          <a
+            href="#"
+            className="forgot-link"
+            onClick={(e) => {
+              e.preventDefault();
+              setShowEmailHelp(true);
+            }}
+          >
+            Forgot Email?
+          </a>
+          <a href="#" className="forgot-link">
+            Forgot Password?
+          </a>
+        </div>
+        <InfoDialog
+          open={showEmailHelp}
+          title="Forgot Email?"
+          onClose={() => setShowEmailHelp(false)}
+        >
+          <p>Instructions on how to find your email go here.</p>
+        </InfoDialog>
       </div>
     </div>
   );

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -68,7 +68,7 @@ button:disabled {
 
 .forgot-link {
   font-size: 0.9rem;
-  color: var(--color-light-blue);
+  color: var(--color-navy);
   text-decoration: none;
 }
 

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -76,6 +76,13 @@ button:disabled {
   text-decoration: underline;
 }
 
+.forgot-links {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 8px;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- add InfoDialog component for simple informational popups
- add a "Forgot Email?" link next to the existing "Forgot Password?" link
- show instructions via InfoDialog when "Forgot Email?" is clicked
- style forgot links container
- test opening the dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f5b1d31c8328815dc46bcb04d0dc