### PR TITLE
Add login security notice

### DIFF
--- a/frontend/src/AppNavigation.test.js
+++ b/frontend/src/AppNavigation.test.js
@@ -78,5 +78,5 @@ test('user can view payment details from dashboard', async () => {
   expect(
     await screen.findByRole('heading', { name: /payment details/i })
   ).toBeInTheDocument();
-  expect(screen.getByText('50')).toBeInTheDocument();
+  expect(screen.getByText('$50')).toBeInTheDocument();
 });

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -75,6 +75,9 @@ export default function LoginPage({ onLogin = () => {} }) {
         <a href="#" className="forgot-link">
           Forgot Password?
         </a>
+        <p className="security-notice">
+          Your information is secured with industry‑standard authentication and encryption.
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -121,3 +121,9 @@ button:disabled {
   }
 }
 
+.security-notice {
+  font-size: 0.75rem;
+  color: #555;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- add security notice under the forgot password link
- style the new notice
- update navigation test to match currency format

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6877f696e1008328afb29c77676519ff