### PR TITLE
Fix member dashboard header spacing

### DIFF
--- a/frontend/src/components/MemberDashboard.js
+++ b/frontend/src/components/MemberDashboard.js
@@ -105,12 +105,10 @@ export default function MemberDashboard({
 
   return (
     <div className="member-dashboard">
-      {user?.isAdmin && onShowAdmin && (
-        <div className="view-toggle-wrapper">
-          <ViewToggle isAdminView={false} onToggle={onShowAdmin} />
-        </div>
-      )}
       <header className="member-dash-header">
+        {user?.isAdmin && onShowAdmin && (
+          <ViewToggle isAdminView={false} onToggle={onShowAdmin} />
+        )}
         <h1>{`Welcome${user?.name ? `, ${user.name}` : ''}!`}</h1>
       </header>
       <div className="balance-info" data-testid="balance-info">

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -8,14 +8,10 @@
 .member-dash-header {
   grid-column: 1 / -1;
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--space-sm);
-  align-items: center;
-  /* removed temporary tinted background */
-  padding: var(--space-sm);
-}
-
-.view-toggle-wrapper {
-  grid-column: 1 / span 2;
+  margin-bottom: 10px;
 }
 
 
@@ -143,9 +139,6 @@
   }
   .member-dash-header h1 {
     flex-basis: 100%;
-  }
-  .view-toggle-wrapper {
-    grid-column: 1 / -1;
   }
   .balance-info,
   .dashboard-content {


### PR DESCRIPTION
## Summary
- move member/admin ViewToggle into the member dashboard header
- match header styles to admin dashboard to reduce spacing

## Testing
- `npm run test:coverage` in `frontend`
- `npm run test:coverage` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6877f79ec6ac8328a2c683439035b0e2