### PR TITLE
Fix admin approve/reject actions

### DIFF
--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -162,7 +162,7 @@ export default function AdminDashboard({
             original: r
           }))}
           renderActions={(row) => (
-            <div className="flex space-x-2">
+            <div className="action-buttons">
               <SecondaryButton
                 onClick={(e) => {
                   e.stopPropagation();

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -163,10 +163,20 @@ export default function AdminDashboard({
           }))}
           renderActions={(row) => (
             <div className="flex space-x-2">
-              <PrimaryButton onClick={() => openApproveDialog(row.original)}>
+              <SecondaryButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openApproveDialog(row.original);
+                }}
+              >
                 Approve
-              </PrimaryButton>
-              <SecondaryButton onClick={() => openDenyDialog(row.original)}>
+              </SecondaryButton>
+              <SecondaryButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openDenyDialog(row.original);
+                }}
+              >
                 Reject
               </SecondaryButton>
             </div>

--- a/frontend/src/styles/Button.css
+++ b/frontend/src/styles/Button.css
@@ -16,6 +16,7 @@
   background-color: #e0e0e0;
   color: var(--color-navy);
   border: 1px solid #ccc;
+  border-radius: 4px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- stop click propagation on approve/reject buttons
- switch approve button to use `SecondaryButton`
- add rounded corners to secondary buttons

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687804724fe883289724d0087d915fff