### PR TITLE
Add mobile hamburger menu

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import '../styles/Header.css';
 import PrimaryButton from './PrimaryButton';
 import NavTab from './NavTab';
@@ -12,73 +13,109 @@ export default function Header({
   onLogout,
   currentPage,
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  function handleNavClick(cb) {
+    return () => {
+      setMenuOpen(false);
+      if (cb) cb();
+    };
+  }
+
+  const tabs = (
+    <>
+      {onShowDashboard && (
+        <NavTab
+          key="dashboard"
+          className="dashboard-tab"
+          active={currentPage === 'dashboard' || currentPage === 'admin'}
+          onClick={handleNavClick(onShowDashboard)}
+        >
+          Dashboard
+        </NavTab>
+      )}
+      {onShowActivity && (
+        <NavTab
+          key="activity"
+          className="activity-tab"
+          active={currentPage === 'activity'}
+          onClick={handleNavClick(onShowActivity)}
+        >
+          Account Activity
+        </NavTab>
+      )}
+      {onShowManageCharges && (
+        <NavTab
+          key="charges"
+          className="charges-tab"
+          active={currentPage === 'manageCharges'}
+          onClick={handleNavClick(onShowManageCharges)}
+        >
+          Manage Charges
+        </NavTab>
+      )}
+      {onShowManagePayments && (
+        <NavTab
+          key="payments"
+          className="payments-tab"
+          active={currentPage === 'managePayments'}
+          onClick={handleNavClick(onShowManagePayments)}
+        >
+          Manage Payments
+        </NavTab>
+      )}
+      {onShowMembers && (
+        <NavTab
+          key="members"
+          className="members-tab"
+          active={currentPage === 'members'}
+          onClick={handleNavClick(onShowMembers)}
+        >
+          Manage Members
+        </NavTab>
+      )}
+    </>
+  );
+
+  const actions = (
+    <>
+      <PrimaryButton
+        type="button"
+        className="logout-button"
+        onClick={handleNavClick(onLogout)}
+        style={{ visibility: onLogout ? 'visible' : 'hidden' }}
+        disabled={!onLogout}
+      >
+        Logout
+      </PrimaryButton>
+      {onShowLogin && (
+        <PrimaryButton type="button" onClick={handleNavClick(onShowLogin)}>
+          Login
+        </PrimaryButton>
+      )}
+    </>
+  );
+
   return (
     <header className="header">
       <nav className="nav">
         <span className="brand">Conclave ΣΧ-ΛΔ</span>
-        <div className="nav-tabs">
-          {onShowDashboard && (
-            <NavTab
-              className="dashboard-tab"
-              active={currentPage === 'dashboard' || currentPage === 'admin'}
-              onClick={onShowDashboard}
-            >
-              Dashboard
-            </NavTab>
-          )}
-          {onShowActivity && (
-            <NavTab
-              className="activity-tab"
-              active={currentPage === 'activity'}
-              onClick={onShowActivity}
-            >
-              Account Activity
-            </NavTab>
-          )}
-          {onShowManageCharges && (
-            <NavTab
-              className="charges-tab"
-              active={currentPage === 'manageCharges'}
-              onClick={onShowManageCharges}
-            >
-              Manage Charges
-            </NavTab>
-          )}
-          {onShowManagePayments && (
-            <NavTab
-              className="payments-tab"
-              active={currentPage === 'managePayments'}
-              onClick={onShowManagePayments}
-            >
-              Manage Payments
-            </NavTab>
-          )}
-          {onShowMembers && (
-            <NavTab
-              className="members-tab"
-              active={currentPage === 'members'}
-              onClick={onShowMembers}
-            >
-              Manage Members
-            </NavTab>
-          )}
-        </div>
-        <div className="nav-actions">
-          <PrimaryButton
-            type="button"
-            className="logout-button"
-            onClick={onLogout}
-            style={{ visibility: onLogout ? 'visible' : 'hidden' }}
-            disabled={!onLogout}
-          >
-            Logout
-          </PrimaryButton>
-          {onShowLogin && (
-            <PrimaryButton type="button" onClick={onShowLogin}>
-              Login
-            </PrimaryButton>
-          )}
-        </div>
+        <button
+          className="hamburger"
+          type="button"
+          aria-label="Toggle menu"
+          onClick={() => setMenuOpen((o) => !o)}
+        >
+          &#9776;
+        </button>
+        <div className="nav-tabs">{tabs}</div>
+        <div className="nav-actions">{actions}</div>
+        {menuOpen && (
+          <div className="mobile-menu open">
+            <div className="nav-tabs">{tabs}</div>
+            <div className="nav-actions">{actions}</div>
+          </div>
+        )}
       </nav>
     </header>
   );

--- a/frontend/src/styles/Header.css
+++ b/frontend/src/styles/Header.css
@@ -2,6 +2,7 @@
   background-color: var(--color-navy);
   padding: 7px 20px;
   color: white;
+  position: relative;
 }
 
 .nav {
@@ -35,4 +36,65 @@
 
 .logout-button {
   padding: 6px 12px;
+}
+
+.hamburger {
+  display: none;
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.mobile-menu {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .nav-tabs {
+    display: none;
+    flex-direction: column;
+    margin: var(--space-sm) 0 0;
+  }
+
+  .nav-actions {
+    display: none;
+  }
+
+  .hamburger {
+    display: block;
+  }
+
+  .mobile-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background-color: var(--color-navy);
+    padding: var(--space-sm) 0;
+    border-top: 1px solid var(--color-light-blue);
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .mobile-menu.open {
+    display: flex;
+  }
+
+  .mobile-menu .nav-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    margin: 0;
+  }
+
+  .mobile-menu .nav-actions {
+    display: flex;
+    flex-direction: column;
+    margin-left: 0;
+    padding: 0 var(--space-sm);
+    gap: var(--space-sm);
+  }
 }


### PR DESCRIPTION
## Summary
- add a responsive hamburger menu implementation for the header
- hide nav tabs and logout/login actions behind the menu on small screens

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68781f16b0e88328ac4312ea62a24cff