### PR TITLE
Fix mobile layout and table pagination

### DIFF
--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -2,12 +2,19 @@ import React, { useState } from 'react';
 import '../styles/AdminDashboard.css';
 import SecondaryButton from './SecondaryButton';
 
+function getDefaultRowsPerPage() {
+  if (typeof window !== 'undefined' && window.innerWidth <= 768) {
+    return 5;
+  }
+  return 10;
+}
+
 export default function DataTable({
   columns = [],
   data = [],
   renderActions,
   loading = false,
-  rowsPerPage = 10,
+  rowsPerPage = getDefaultRowsPerPage(),
   onRowClick
 }) {
   const [page, setPage] = useState(0);

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -150,6 +150,12 @@
   .member-dash-header h1 {
     flex-basis: 100%;
   }
+  .balance-summary {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .balance-card {
+    min-width: 0;
+  }
   .balance-info,
   .dashboard-content {
     grid-column: 1 / -1;


### PR DESCRIPTION
## Summary
- use 5 rows per page for tables on small screens
- tweak member dashboard CSS so balance cards fit on mobile

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68781fd4ce5c8328821c326c5ed2030d