### PR TITLE
Persist current page

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -1,5 +1,5 @@
 import '../styles/App.css';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { supabase } from '../supabaseClient';
 import { useAuth } from '../AuthContext';
 import LoginPage from './LoginPage';
@@ -16,13 +16,19 @@ import AppShell from './AppShell';
 import AccountActivityPage from './AccountActivityPage';
 
 function App() {
-  const [currentPage, setCurrentPage] = useState('login');
+  const [currentPage, setCurrentPage] = useState(
+    () => localStorage.getItem('currentPage') || 'login'
+  );
   const [reviewCharge, setReviewCharge] = useState(null);
   const [detailsCharge, setDetailsCharge] = useState(null);
   const [detailsPayment, setDetailsPayment] = useState(null);
   const [pendingReviewIds, setPendingReviewIds] = useState([]);
   const [isAdminView, setIsAdminView] = useState(false);
   const { token, setToken, setUser, user } = useAuth();
+
+  useEffect(() => {
+    localStorage.setItem('currentPage', currentPage);
+  }, [currentPage]);
 
   const showMemberDashboard = () => {
     setIsAdminView(false);
@@ -52,6 +58,7 @@ function App() {
     } finally {
       setToken(null);
       setUser(null);
+      localStorage.removeItem('currentPage');
       setIsAdminView(false);
       showLogin();
     }

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -33,6 +33,7 @@ export default function LoginPage({ onLogin = () => {} }) {
       setToken(token);
       const member = await api.fetchMember();
       setUser(member);
+      localStorage.setItem('currentPage', 'dashboard');
       onLogin();
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- initialize current page from `localStorage`
- persist page navigation in `localStorage`
- clean current page on logout
- set dashboard as the page after successful login

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687823d285388328bab9a341b13f476d