### PR TITLE
Improve mobile table layout

### DIFF
--- a/frontend/src/components/DataTable.js
+++ b/frontend/src/components/DataTable.js
@@ -61,7 +61,11 @@ export default function DataTable({
                   typeof value === 'number' &&
                   c.header.toLowerCase().includes('amount');
                 const display = isMoney ? `$${value}` : value;
-                return <td key={c.accessor}>{display}</td>;
+                return (
+                  <td key={c.accessor} data-label={c.header}>
+                    {display}
+                  </td>
+                );
               })}
               {renderActions && <td>{renderActions(row)}</td>}
               {onRowClick && <td className="row-arrow">&#x276F;</td>}

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -162,4 +162,29 @@
   .admin-dash-header h1 {
     flex-basis: 100%;
   }
+  .admin-table {
+    border-spacing: 0;
+  }
+  .admin-table thead {
+    display: none;
+  }
+  .admin-table tbody tr {
+    display: block;
+    margin-bottom: var(--space-sm);
+  }
+  .admin-table tbody tr td {
+    display: flex;
+    justify-content: space-between;
+    padding: var(--space-xs) var(--space-sm);
+    width: 100%;
+  }
+  .admin-table tbody tr td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    margin-right: var(--space-sm);
+  }
+  .admin-table th.arrow-col,
+  .admin-table td.row-arrow {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
- enable DataTable to render mobile labels with `data-label`
- stack DataTable rows vertically on small screens

## Testing
- `npm run test --silent` in `frontend`
- `npm run test:coverage --silent` in `frontend`
- `npm test --silent` in `backend`
- `npm run test:coverage --silent` in `backend` *(fails to finish)*

------
https://chatgpt.com/codex/tasks/task_e_687847228eb48328a6453be8c9f96cb4