### PR TITLE
Fix hover effects on account activity rows

### DIFF
--- a/frontend/src/components/ChargeList.js
+++ b/frontend/src/components/ChargeList.js
@@ -8,7 +8,7 @@ import SecondaryButton from './SecondaryButton';
 export default function ChargeList({
   charges = [],
   onRequestReview = () => {},
-  onViewDetails = () => {},
+  onViewDetails,
   pendingReviewIds = [],
   loading = false,
 }) {
@@ -49,12 +49,8 @@ export default function ChargeList({
     };
   });
 
-  return (
-    <DataTable
-      loading={loading}
-      columns={columns}
-      data={rows}
-      onRowClick={(row) =>
+  const rowClick = onViewDetails
+    ? (row) =>
         onViewDetails({
           id: row.original.id,
           status: row.original.status,
@@ -64,7 +60,14 @@ export default function ChargeList({
           partialAmountPaid: row.original.partialAmountPaid,
           updatedAt: row.original.updatedAt
         })
-      }
+    : undefined;
+
+  return (
+    <DataTable
+      loading={loading}
+      columns={columns}
+      data={rows}
+      onRowClick={rowClick}
     />
   );
 }

--- a/frontend/src/components/PaymentList.js
+++ b/frontend/src/components/PaymentList.js
@@ -3,7 +3,7 @@ import DataTable from './DataTable';
 import '../styles/PaymentList.css';
 import logo from '../assets/images/UC-Merced-SigmaChi-ExpectMore.svg';
 
-export default function PaymentList({ payments = [], loading = false, onViewDetails = () => {} }) {
+export default function PaymentList({ payments = [], loading = false, onViewDetails }) {
   if (!loading && payments.length === 0) {
     return (
       <div className="table-empty">
@@ -24,12 +24,16 @@ export default function PaymentList({ payments = [], loading = false, onViewDeta
     paidDate: new Date(p.date).toLocaleDateString(),
     original: p
   }));
+  const rowClick = onViewDetails
+    ? (row) => onViewDetails(row.original)
+    : undefined;
+
   return (
     <DataTable
       columns={columns}
       data={rows}
       loading={loading}
-      onRowClick={(row) => onViewDetails(row.original)}
+      onRowClick={rowClick}
     />
   );
 }


### PR DESCRIPTION
## Summary
- prevent DataTable hover styles on account activity lists when rows aren't clickable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68784cb3d1dc832899c6126ae748d787