### PR TITLE
Fix layout for dashboard headers

### DIFF
--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -21,8 +21,8 @@
 
 .admin-dash-header {
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
   margin-bottom: 10px;
 }

--- a/frontend/src/styles/MemberDashboard.css
+++ b/frontend/src/styles/MemberDashboard.css
@@ -8,8 +8,8 @@
 .member-dash-header {
   grid-column: 1 / -1;
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--space-sm);
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- stack view toggle over header text in Member and Admin dashboards

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68785afa744483288f236aaca865a799